### PR TITLE
Add an Upload feature to program the keyboard from Easy AVR itself

### DIFF
--- a/keymapper/easykeymap/exttools/HostLoaderApp/Makefile
+++ b/keymapper/easykeymap/exttools/HostLoaderApp/Makefile
@@ -1,0 +1,40 @@
+OS ?= LINUX
+#OS ?= WINDOWS
+#OS ?= MACOSX
+#OS ?= BSD
+
+ifeq ($(OS), LINUX)  # also works on FreeBSD
+CC ?= gcc
+CFLAGS ?= -O2 -Wall
+hid_bootloader_cli: hid_bootloader_cli.c
+	$(CC) $(CFLAGS) -s -DUSE_LIBUSB -o ../hid_bootloader_cli hid_bootloader_cli.c -lusb
+
+
+else ifeq ($(OS), WINDOWS)
+CC = i586-mingw32msvc-gcc
+CFLAGS ?= -O2 -Wall
+LDLIB = -lsetupapi -lhid
+hid_bootloader_cli.exe: hid_bootloader_cli.c
+	$(CC) $(CFLAGS) -s -DUSE_WIN32 -o ../hid_bootloader_cli.exe hid_bootloader_cli.c $(LDLIB)
+
+
+else ifeq ($(OS), MACOSX)
+CC ?= gcc
+SDK ?= /Developer/SDKs/MacOSX10.5.sdk
+CFLAGS ?= -O2 -Wall
+hid_bootloader_cli: hid_bootloader_cli.c
+	$(CC) $(CFLAGS) -DUSE_APPLE_IOKIT -isysroot $(SDK) -o ../hid_bootloader_cli hid_bootloader_cli.c -Wl,-syslibroot,$(SDK) -framework IOKit -framework CoreFoundation
+
+
+else ifeq ($(OS), BSD)  # works on NetBSD and OpenBSD
+CC ?= gcct
+CFLAGS ?= -O2 -Wall
+hid_bootloader_cli: hid_bootloader_cli.c
+	$(CC) $(CFLAGS) -s -DUSE_UHID -o ../hid_bootloader_cli hid_bootloader_cli.c
+
+
+endif
+
+
+clean:
+	rm -f ../hid_bootloader_cli ../hid_bootloader_cli.exe

--- a/keymapper/easykeymap/exttools/HostLoaderApp/Makefile.bsd
+++ b/keymapper/easykeymap/exttools/HostLoaderApp/Makefile.bsd
@@ -1,0 +1,21 @@
+OS ?= FreeBSD
+#OS ?= NetBSD
+#OS ?= OpenBSD
+
+CFLAGS ?= -O2 -Wall
+CC ?= gcc
+
+.if $(OS) == "FreeBSD"
+CFLAGS += -DUSE_LIBUSB
+LIBS =  -lusb
+.elif $(OS) == "NetBSD" || $(OS) == "OpenBSD"
+CFLAGS += -DUSE_UHID
+LIBS =
+.endif
+
+
+hid_bootloader_cli: hid_bootloader_cli.c
+	$(CC) $(CFLAGS) -s -o ../hid_bootloader_cli hid_bootloader_cli.c $(LIBS)
+
+clean:
+	rm -f ../hid_bootloader_cli

--- a/keymapper/easykeymap/exttools/HostLoaderApp/gpl3.txt
+++ b/keymapper/easykeymap/exttools/HostLoaderApp/gpl3.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/keymapper/easykeymap/exttools/HostLoaderApp/hid_bootloader_cli.c
+++ b/keymapper/easykeymap/exttools/HostLoaderApp/hid_bootloader_cli.c
@@ -1,0 +1,1010 @@
+/* Modified for the LUFA HID Bootloader by Dean Camera
+ *           http://www.lufa-lib.org
+ *
+ *   THIS MODIFIED VERSION IS UNSUPPORTED BY PJRC.
+ */
+
+/* Teensy Loader, Command Line Interface
+ * Program and Reboot Teensy Board with HalfKay Bootloader
+ * http://www.pjrc.com/teensy/loader_cli.html
+ * Copyright 2008-2010, PJRC.COM, LLC
+ *
+ *
+ * You may redistribute this program and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software
+ * Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+/* Want to incorporate this code into a proprietary application??
+ * Just email paul@pjrc.com to ask.  Usually it's not a problem,
+ * but you do need to ask to use this code in any way other than
+ * those permitted by the GNU General Public License, version 3  */
+
+/* For non-root permissions on ubuntu or similar udev-based linux
+ * http://www.pjrc.com/teensy/49-teensy.rules
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+#include <unistd.h>
+
+void usage(void)
+{
+	fprintf(stderr, "Usage: hid_bootloader_cli -mmcu=<MCU> [-w] [-h] [-n] [-v] <file.hex>\n");
+	fprintf(stderr, "\t-w : Wait for device to appear\n");
+	fprintf(stderr, "\t-r : Use hard reboot if device not online\n");
+	fprintf(stderr, "\t-n : No reboot after programming\n");
+	fprintf(stderr, "\t-v : Verbose output\n");
+	fprintf(stderr, "\n<MCU> = atmegaXXuY or at90usbXXXY");
+
+	fprintf(stderr, "\nFor support and more information, please visit:\n");
+	fprintf(stderr, "http://www.lufa-lib.org\n");
+
+	fprintf(stderr, "\nBased on the TeensyHID command line programmer software:\n");
+	fprintf(stderr, "http://www.pjrc.com/teensy/loader_cli.html\n");
+	exit(1);
+}
+
+// USB Access Functions
+int teensy_open(void);
+int teensy_write(void *buf, int len, double timeout);
+void teensy_close(void);
+int hard_reboot(void);
+
+// Intel Hex File Functions
+int read_intel_hex(const char *filename);
+int ihex_bytes_within_range(int begin, int end);
+void ihex_get_data(int addr, int len, unsigned char *bytes);
+
+// Misc stuff
+int printf_verbose(const char *format, ...);
+void delay(double seconds);
+void die(const char *str, ...);
+void parse_options(int argc, char **argv);
+
+// options (from user via command line args)
+int wait_for_device_to_appear = 0;
+int hard_reboot_device = 0;
+int reboot_after_programming = 1;
+int verbose = 0;
+int code_size = 0, block_size = 0;
+const char *filename=NULL;
+
+
+/****************************************************************/
+/*                                                              */
+/*                       Main Program                           */
+/*                                                              */
+/****************************************************************/
+
+int main(int argc, char **argv)
+{
+	unsigned char buf[260];
+	int num, addr, r, first_block=1, waited=0;
+
+	// parse command line arguments
+	parse_options(argc, argv);
+	if (!filename) {
+		fprintf(stderr, "Filename must be specified\n\n");
+		usage();
+	}
+	if (!code_size) {
+		fprintf(stderr, "MCU type must be specified\n\n");
+		usage();
+	}
+	printf_verbose("Teensy Loader, Command Line, Version 2.0\n");
+
+	// read the intel hex file
+	// this is done first so any error is reported before using USB
+	num = read_intel_hex(filename);
+	if (num < 0) die("error reading intel hex file \"%s\"", filename);
+	printf_verbose("Read \"%s\": %d bytes, %.1f%% usage\n",
+		filename, num, (double)num / (double)code_size * 100.0);
+
+	// open the USB device
+	while (1) {
+		if (teensy_open()) break;
+		if (hard_reboot_device) {
+			if (!hard_reboot()) die("Unable to find rebootor\n");
+			printf_verbose("Hard Reboot performed\n");
+			hard_reboot_device = 0; // only hard reboot once
+			wait_for_device_to_appear = 1;
+		}
+		if (!wait_for_device_to_appear) die("Unable to open device\n");
+		if (!waited) {
+			printf_verbose("Waiting for Teensy device...\n");
+			printf_verbose(" (hint: press the reset button)\n");
+			waited = 1;
+		}
+		delay(0.25);
+	}
+	printf_verbose("Found HalfKay Bootloader\n");
+
+	// if we waited for the device, read the hex file again
+	// perhaps it changed while we were waiting?
+	if (waited) {
+		num = read_intel_hex(filename);
+		if (num < 0) die("error reading intel hex file \"%s\"", filename);
+		printf_verbose("Read \"%s\": %d bytes, %.1f%% usage\n",
+		 	filename, num, (double)num / (double)code_size * 100.0);
+	}
+
+	// program the data
+	printf_verbose("Programming");
+	fflush(stdout);
+	for (addr = 0; addr < code_size; addr += block_size) {
+		if (addr > 0 && !ihex_bytes_within_range(addr, addr + block_size - 1)) {
+			// don't waste time on blocks that are unused,
+			// but always do the first one to erase the chip
+			continue;
+		}
+		printf_verbose(".");
+		if (code_size < 0x10000) {
+			buf[0] = addr & 255;
+			buf[1] = (addr >> 8) & 255;
+		} else {
+			buf[0] = (addr >> 8) & 255;
+			buf[1] = (addr >> 16) & 255;
+		}
+		ihex_get_data(addr, block_size, buf + 2);
+		r = teensy_write(buf, block_size + 2, first_block ? 3.0 : 0.25);
+		if (!r) die("error writing to Teensy\n");
+		first_block = 0;
+	}
+	printf_verbose("\n");
+
+	// reboot to the user's new code
+	if (reboot_after_programming) {
+		printf_verbose("Booting\n");
+		buf[0] = 0xFF;
+		buf[1] = 0xFF;
+		memset(buf + 2, 0, sizeof(buf) - 2);
+		teensy_write(buf, block_size + 2, 0.25);
+	}
+	teensy_close();
+	return 0;
+}
+
+
+
+
+/****************************************************************/
+/*                                                              */
+/*             USB Access - libusb (Linux & FreeBSD)            */
+/*                                                              */
+/****************************************************************/
+
+#if defined(USE_LIBUSB)
+
+// http://libusb.sourceforge.net/doc/index.html
+#include <usb.h>
+
+usb_dev_handle * open_usb_device(int vid, int pid)
+{
+	struct usb_bus *bus;
+	struct usb_device *dev;
+	usb_dev_handle *h;
+	#ifdef LIBUSB_HAS_GET_DRIVER_NP
+	char buf[128];
+	#endif
+	int r;
+
+	usb_init();
+	usb_find_busses();
+	usb_find_devices();
+	//printf_verbose("\nSearching for USB device:\n");
+	for (bus = usb_get_busses(); bus; bus = bus->next) {
+		for (dev = bus->devices; dev; dev = dev->next) {
+			//printf_verbose("bus \"%s\", device \"%s\" vid=%04X, pid=%04X\n",
+			//	bus->dirname, dev->filename,
+			//	dev->descriptor.idVendor,
+			//	dev->descriptor.idProduct
+			//);
+			if (dev->descriptor.idVendor != vid) continue;
+			if (dev->descriptor.idProduct != pid) continue;
+			h = usb_open(dev);
+			if (!h) {
+				printf_verbose("Found device but unable to open");
+				continue;
+			}
+			#ifdef LIBUSB_HAS_GET_DRIVER_NP
+			r = usb_get_driver_np(h, 0, buf, sizeof(buf));
+			if (r >= 0) {
+				r = usb_detach_kernel_driver_np(h, 0);
+				if (r < 0) {
+					usb_close(h);
+					printf_verbose("Device is in use by \"%s\" driver", buf);
+					continue;
+				}
+			}
+			#endif
+			// Mac OS-X - removing this call to usb_claim_interface() might allow
+			// this to work, even though it is a clear misuse of the libusb API.
+			// normally Apple's IOKit should be used on Mac OS-X
+			r = usb_claim_interface(h, 0);
+			if (r < 0) {
+				usb_close(h);
+				printf_verbose("Unable to claim interface, check USB permissions");
+				continue;
+			}
+			return h;
+		}
+	}
+	return NULL;
+}
+
+static usb_dev_handle *libusb_teensy_handle = NULL;
+
+int teensy_open(void)
+{
+	teensy_close();
+	libusb_teensy_handle = open_usb_device(0x16C0, 0x0478);
+
+	if (!libusb_teensy_handle)
+		libusb_teensy_handle = open_usb_device(0x03eb, 0x2067);
+
+	if (!libusb_teensy_handle) return 0;
+	return 1;
+}
+
+int teensy_write(void *buf, int len, double timeout)
+{
+	int r;
+
+	if (!libusb_teensy_handle) return 0;
+	r = usb_control_msg(libusb_teensy_handle, 0x21, 9, 0x0200, 0, (char *)buf,
+		len, (int)(timeout * 1000.0));
+	if (r < 0) return 0;
+	return 1;
+}
+
+void teensy_close(void)
+{
+	if (!libusb_teensy_handle) return;
+	usb_release_interface(libusb_teensy_handle, 0);
+	usb_close(libusb_teensy_handle);
+	libusb_teensy_handle = NULL;
+}
+
+int hard_reboot(void)
+{
+	usb_dev_handle *rebootor;
+	int r;
+
+	rebootor = open_usb_device(0x16C0, 0x0477);
+
+	if (!rebootor)
+		rebootor = open_usb_device(0x03eb, 0x2067);
+
+	if (!rebootor) return 0;
+	r = usb_control_msg(rebootor, 0x21, 9, 0x0200, 0, "reboot", 6, 100);
+	usb_release_interface(rebootor, 0);
+	usb_close(rebootor);
+	if (r < 0) return 0;
+	return 1;
+}
+
+#endif
+
+
+/****************************************************************/
+/*                                                              */
+/*               USB Access - Microsoft WIN32                   */
+/*                                                              */
+/****************************************************************/
+
+#if defined(USE_WIN32)
+
+// http://msdn.microsoft.com/en-us/library/ms790932.aspx
+#include <windows.h>
+#include <setupapi.h>
+#include <ddk/hidsdi.h>
+#include <ddk/hidclass.h>
+
+HANDLE open_usb_device(int vid, int pid)
+{
+	GUID guid;
+	HDEVINFO info;
+	DWORD index, required_size;
+	SP_DEVICE_INTERFACE_DATA iface;
+	SP_DEVICE_INTERFACE_DETAIL_DATA *details;
+	HIDD_ATTRIBUTES attrib;
+	HANDLE h;
+	BOOL ret;
+
+	HidD_GetHidGuid(&guid);
+	info = SetupDiGetClassDevs(&guid, NULL, NULL, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+	if (info == INVALID_HANDLE_VALUE) return NULL;
+	for (index=0; 1 ;index++) {
+		iface.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
+		ret = SetupDiEnumDeviceInterfaces(info, NULL, &guid, index, &iface);
+		if (!ret) {
+			SetupDiDestroyDeviceInfoList(info);
+			break;
+		}
+		SetupDiGetInterfaceDeviceDetail(info, &iface, NULL, 0, &required_size, NULL);
+		details = (SP_DEVICE_INTERFACE_DETAIL_DATA *)malloc(required_size);
+		if (details == NULL) continue;
+		memset(details, 0, required_size);
+		details->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
+		ret = SetupDiGetDeviceInterfaceDetail(info, &iface, details,
+			required_size, NULL, NULL);
+		if (!ret) {
+			free(details);
+			continue;
+		}
+		h = CreateFile(details->DevicePath, GENERIC_READ|GENERIC_WRITE,
+			FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
+			FILE_FLAG_OVERLAPPED, NULL);
+		free(details);
+		if (h == INVALID_HANDLE_VALUE) continue;
+		attrib.Size = sizeof(HIDD_ATTRIBUTES);
+		ret = HidD_GetAttributes(h, &attrib);
+		if (!ret) {
+			CloseHandle(h);
+			continue;
+		}
+		if (attrib.VendorID != vid || attrib.ProductID != pid) {
+			CloseHandle(h);
+			continue;
+		}
+		SetupDiDestroyDeviceInfoList(info);
+		return h;
+	}
+	return NULL;
+}
+
+int write_usb_device(HANDLE h, void *buf, int len, int timeout)
+{
+	static HANDLE event = NULL;
+	unsigned char tmpbuf[1040];
+	OVERLAPPED ov;
+	DWORD n, r;
+
+	if (len > sizeof(tmpbuf) - 1) return 0;
+	if (event == NULL) {
+		event = CreateEvent(NULL, TRUE, TRUE, NULL);
+		if (!event) return 0;
+	}
+	ResetEvent(&event);
+	memset(&ov, 0, sizeof(ov));
+	ov.hEvent = event;
+	tmpbuf[0] = 0;
+	memcpy(tmpbuf + 1, buf, len);
+	if (!WriteFile(h, tmpbuf, len + 1, NULL, &ov)) {
+		if (GetLastError() != ERROR_IO_PENDING) return 0;
+		r = WaitForSingleObject(event, timeout);
+		if (r == WAIT_TIMEOUT) {
+			CancelIo(h);
+			return 0;
+		}
+		if (r != WAIT_OBJECT_0) return 0;
+	}
+	if (!GetOverlappedResult(h, &ov, &n, FALSE)) return 0;
+	return 1;
+}
+
+static HANDLE win32_teensy_handle = NULL;
+
+int teensy_open(void)
+{
+	teensy_close();
+	win32_teensy_handle = open_usb_device(0x16C0, 0x0478);
+
+	if (!win32_teensy_handle)
+		win32_teensy_handle = open_usb_device(0x03eb, 0x2067);
+
+	if (!win32_teensy_handle) return 0;
+	return 1;
+}
+
+int teensy_write(void *buf, int len, double timeout)
+{
+	int r;
+	if (!win32_teensy_handle) return 0;
+	r = write_usb_device(win32_teensy_handle, buf, len, (int)(timeout * 1000.0));
+	return r;
+}
+
+void teensy_close(void)
+{
+	if (!win32_teensy_handle) return;
+	CloseHandle(win32_teensy_handle);
+	win32_teensy_handle = NULL;
+}
+
+int hard_reboot(void)
+{
+	HANDLE rebootor;
+	int r;
+
+	rebootor = open_usb_device(0x16C0, 0x0477);
+
+	if (!rebootor)
+		rebootor = open_usb_device(0x03eb, 0x2067);
+
+	if (!rebootor) return 0;
+	r = write_usb_device(rebootor, "reboot", 6, 100);
+	CloseHandle(rebootor);
+	return r;
+}
+
+#endif
+
+
+
+/****************************************************************/
+/*                                                              */
+/*             USB Access - Apple's IOKit, Mac OS-X             */
+/*                                                              */
+/****************************************************************/
+
+#if defined(USE_APPLE_IOKIT)
+
+// http://developer.apple.com/technotes/tn2007/tn2187.html
+#include <IOKit/IOKitLib.h>
+#include <IOKit/hid/IOHIDLib.h>
+#include <IOKit/hid/IOHIDDevice.h>
+
+struct usb_list_struct {
+	IOHIDDeviceRef ref;
+	int pid;
+	int vid;
+	struct usb_list_struct *next;
+};
+
+static struct usb_list_struct *usb_list=NULL;
+static IOHIDManagerRef hid_manager=NULL;
+
+void attach_callback(void *context, IOReturn r, void *hid_mgr, IOHIDDeviceRef dev)
+{
+	CFTypeRef type;
+	struct usb_list_struct *n, *p;
+	int32_t pid, vid;
+
+	if (!dev) return;
+	type = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDVendorIDKey));
+	if (!type || CFGetTypeID(type) != CFNumberGetTypeID()) return;
+	if (!CFNumberGetValue((CFNumberRef)type, kCFNumberSInt32Type, &vid)) return;
+	type = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDProductIDKey));
+	if (!type || CFGetTypeID(type) != CFNumberGetTypeID()) return;
+	if (!CFNumberGetValue((CFNumberRef)type, kCFNumberSInt32Type, &pid)) return;
+	n = (struct usb_list_struct *)malloc(sizeof(struct usb_list_struct));
+	if (!n) return;
+	//printf("attach callback: vid=%04X, pid=%04X\n", vid, pid);
+	n->ref = dev;
+	n->vid = vid;
+	n->pid = pid;
+	n->next = NULL;
+	if (usb_list == NULL) {
+		usb_list = n;
+	} else {
+		for (p = usb_list; p->next; p = p->next) ;
+		p->next = n;
+	}
+}
+
+void detach_callback(void *context, IOReturn r, void *hid_mgr, IOHIDDeviceRef dev)
+{
+	struct usb_list_struct *p, *tmp, *prev=NULL;
+
+	p = usb_list;
+	while (p) {
+		if (p->ref == dev) {
+			if (prev) {
+				prev->next = p->next;
+			} else {
+				usb_list = p->next;
+			}
+			tmp = p;
+			p = p->next;
+			free(tmp);
+		} else {
+			prev = p;
+			p = p->next;
+		}
+	}
+}
+
+void init_hid_manager(void)
+{
+	CFMutableDictionaryRef dict;
+	IOReturn ret;
+
+	if (hid_manager) return;
+	hid_manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+	if (hid_manager == NULL || CFGetTypeID(hid_manager) != IOHIDManagerGetTypeID()) {
+		if (hid_manager) CFRelease(hid_manager);
+		printf_verbose("no HID Manager - maybe this is a pre-Leopard (10.5) system?\n");
+		return;
+	}
+	dict = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+		&kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	if (!dict) return;
+	IOHIDManagerSetDeviceMatching(hid_manager, dict);
+	CFRelease(dict);
+	IOHIDManagerScheduleWithRunLoop(hid_manager, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+	IOHIDManagerRegisterDeviceMatchingCallback(hid_manager, attach_callback, NULL);
+	IOHIDManagerRegisterDeviceRemovalCallback(hid_manager, detach_callback, NULL);
+	ret = IOHIDManagerOpen(hid_manager, kIOHIDOptionsTypeNone);
+	if (ret != kIOReturnSuccess) {
+		IOHIDManagerUnscheduleFromRunLoop(hid_manager,
+			CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+		CFRelease(hid_manager);
+		printf_verbose("Error opening HID Manager");
+	}
+}
+
+static void do_run_loop(void)
+{
+	while (CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true) == kCFRunLoopRunHandledSource) ;
+}
+
+IOHIDDeviceRef open_usb_device(int vid, int pid)
+{
+	struct usb_list_struct *p;
+	IOReturn ret;
+
+	init_hid_manager();
+	do_run_loop();
+	for (p = usb_list; p; p = p->next) {
+		if (p->vid == vid && p->pid == pid) {
+			ret = IOHIDDeviceOpen(p->ref, kIOHIDOptionsTypeNone);
+			if (ret == kIOReturnSuccess) return p->ref;
+		}
+	}
+	return NULL;
+}
+
+void close_usb_device(IOHIDDeviceRef dev)
+{
+	struct usb_list_struct *p;
+
+	do_run_loop();
+	for (p = usb_list; p; p = p->next) {
+		if (p->ref == dev) {
+			IOHIDDeviceClose(dev, kIOHIDOptionsTypeNone);
+			return;
+		}
+	}
+}
+
+static IOHIDDeviceRef iokit_teensy_reference = NULL;
+
+int teensy_open(void)
+{
+	teensy_close();
+	iokit_teensy_reference = open_usb_device(0x16C0, 0x0478);
+
+	if (!iokit_teensy_reference)
+		iokit_teensy_reference = open_usb_device(0x03eb, 0x2067);
+
+	if (!iokit_teensy_reference) return 0;
+	return 1;
+}
+
+int teensy_write(void *buf, int len, double timeout)
+{
+	IOReturn ret;
+
+	// timeouts do not work on OS-X
+	// IOHIDDeviceSetReportWithCallback is not implemented
+	// even though Apple documents it with a code example!
+	// submitted to Apple on 22-sep-2009, problem ID 7245050
+	if (!iokit_teensy_reference) return 0;
+	ret = IOHIDDeviceSetReport(iokit_teensy_reference,
+		kIOHIDReportTypeOutput, 0, buf, len);
+	if (ret == kIOReturnSuccess) return 1;
+	return 0;
+}
+
+void teensy_close(void)
+{
+	if (!iokit_teensy_reference) return;
+	close_usb_device(iokit_teensy_reference);
+	iokit_teensy_reference = NULL;
+}
+
+int hard_reboot(void)
+{
+	IOHIDDeviceRef rebootor;
+	IOReturn ret;
+
+	rebootor = open_usb_device(0x16C0, 0x0477);
+
+	if (!rebootor)
+		rebootor = open_usb_device(0x03eb, 0x2067);
+
+	if (!rebootor) return 0;
+	ret = IOHIDDeviceSetReport(rebootor,
+		kIOHIDReportTypeOutput, 0, (uint8_t *)("reboot"), 6);
+	close_usb_device(rebootor);
+	if (ret == kIOReturnSuccess) return 1;
+	return 0;
+}
+
+#endif
+
+
+
+/****************************************************************/
+/*                                                              */
+/*              USB Access - BSD's UHID driver                  */
+/*                                                              */
+/****************************************************************/
+
+#if defined(USE_UHID)
+
+// Thanks to Todd T Fries for help getting this working on OpenBSD
+// and to Chris Kuethe for the initial patch to use UHID.
+
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <dev/usb/usb.h>
+#ifndef USB_GET_DEVICEINFO
+#include <dev/usb/usb_ioctl.h>
+#endif
+
+#ifndef USB_GET_DEVICEINFO
+# define USB_GET_DEVICEINFO 0
+# error The USB_GET_DEVICEINFO ioctl() value is not defined for your system.
+#endif
+
+int open_usb_device(int vid, int pid)
+{
+	int r, fd;
+	DIR *dir;
+	struct dirent *d;
+	struct usb_device_info info;
+	char buf[256];
+
+	dir = opendir("/dev");
+	if (!dir) return -1;
+	while ((d = readdir(dir)) != NULL) {
+		if (strncmp(d->d_name, "uhid", 4) != 0) continue;
+		snprintf(buf, sizeof(buf), "/dev/%s", d->d_name);
+		fd = open(buf, O_RDWR);
+		if (fd < 0) continue;
+		r = ioctl(fd, USB_GET_DEVICEINFO, &info);
+		if (r < 0) {
+			// NetBSD: added in 2004
+			// OpenBSD: added November 23, 2009
+			// FreeBSD: missing (FreeBSD 8.0) - USE_LIBUSB works!
+			die("Error: your uhid driver does not support"
+			  " USB_GET_DEVICEINFO, please upgrade!\n");
+			close(fd);
+			closedir(dir);
+			exit(1);
+		}
+		//printf("%s: v=%d, p=%d\n", buf, info.udi_vendorNo, info.udi_productNo);
+		if (info.udi_vendorNo == vid && info.udi_productNo == pid) {
+			closedir(dir);
+			return fd;
+		}
+		close(fd);
+	}
+	closedir(dir);
+	return -1;
+}
+
+static int uhid_teensy_fd = -1;
+
+int teensy_open(void)
+{
+	teensy_close();
+	uhid_teensy_fd = open_usb_device(0x16C0, 0x0478);
+
+	if (uhid_teensy_fd < 0)
+		uhid_teensy_fd = open_usb_device(0x03eb, 0x2067);
+
+	if (uhid_teensy_fd < 0) return 0;
+	return 1;
+}
+
+int teensy_write(void *buf, int len, double timeout)
+{
+	int r;
+
+	// TODO: implement timeout... how??
+	r = write(uhid_teensy_fd, buf, len);
+	if (r == len) return 1;
+	return 0;
+}
+
+void teensy_close(void)
+{
+	if (uhid_teensy_fd >= 0) {
+		close(uhid_teensy_fd);
+		uhid_teensy_fd = -1;
+	}
+}
+
+int hard_reboot(void)
+{
+	int r, rebootor_fd;
+
+	rebootor_fd = open_usb_device(0x16C0, 0x0477);
+
+	if (rebootor_fd < 0)
+		rebootor_fd = open_usb_device(0x03eb, 0x2067);
+
+	if (rebootor_fd < 0) return 0;
+	r = write(rebootor_fd, "reboot", 6);
+	delay(0.1);
+	close(rebootor_fd);
+	if (r == 6) return 1;
+	return 0;
+}
+
+#endif
+
+
+
+/****************************************************************/
+/*                                                              */
+/*                     Read Intel Hex File                      */
+/*                                                              */
+/****************************************************************/
+
+// the maximum flash image size we can support
+// chips with larger memory may be used, but only this
+// much intel-hex data can be loaded into memory!
+#define MAX_MEMORY_SIZE 0x20000
+
+static unsigned char firmware_image[MAX_MEMORY_SIZE];
+static unsigned char firmware_mask[MAX_MEMORY_SIZE];
+static int end_record_seen=0;
+static int byte_count;
+static unsigned int extended_addr = 0;
+static int parse_hex_line(char *line);
+
+int read_intel_hex(const char *filename)
+{
+	FILE *fp;
+	int i, lineno=0;
+	char buf[1024];
+
+	byte_count = 0;
+	end_record_seen = 0;
+	for (i=0; i<MAX_MEMORY_SIZE; i++) {
+		firmware_image[i] = 0xFF;
+		firmware_mask[i] = 0;
+	}
+	extended_addr = 0;
+
+	fp = fopen(filename, "r");
+	if (fp == NULL) {
+		//printf("Unable to read file %s\n", filename);
+		return -1;
+	}
+	while (!feof(fp)) {
+		*buf = '\0';
+		if (!fgets(buf, sizeof(buf), fp)) break;
+		lineno++;
+		if (*buf) {
+			if (parse_hex_line(buf) == 0) {
+				//printf("Warning, parse error line %d\n", lineno);
+				fclose(fp);
+				return -2;
+			}
+		}
+		if (end_record_seen) break;
+		if (feof(stdin)) break;
+	}
+	fclose(fp);
+	return byte_count;
+}
+
+
+/* from ihex.c, at http://www.pjrc.com/tech/8051/pm2_docs/intel-hex.html */
+
+/* parses a line of intel hex code, stores the data in bytes[] */
+/* and the beginning address in addr, and returns a 1 if the */
+/* line was valid, or a 0 if an error occurred.  The variable */
+/* num gets the number of bytes that were stored into bytes[] */
+
+
+int
+parse_hex_line(char *line)
+{
+	int addr, code, num;
+        int sum, len, cksum, i;
+        char *ptr;
+
+        num = 0;
+        if (line[0] != ':') return 0;
+        if (strlen(line) < 11) return 0;
+        ptr = line+1;
+        if (!sscanf(ptr, "%02x", &len)) return 0;
+        ptr += 2;
+        if ((int)strlen(line) < (11 + (len * 2)) ) return 0;
+        if (!sscanf(ptr, "%04x", &addr)) return 0;
+        ptr += 4;
+          /* printf("Line: length=%d Addr=%d\n", len, addr); */
+        if (!sscanf(ptr, "%02x", &code)) return 0;
+	if (addr + extended_addr + len >= MAX_MEMORY_SIZE) return 0;
+        ptr += 2;
+        sum = (len & 255) + ((addr >> 8) & 255) + (addr & 255) + (code & 255);
+	if (code != 0) {
+		if (code == 1) {
+			end_record_seen = 1;
+			return 1;
+		}
+		if (code == 2 && len == 2) {
+			if (!sscanf(ptr, "%04x", &i)) return 1;
+			ptr += 4;
+			sum += ((i >> 8) & 255) + (i & 255);
+        		if (!sscanf(ptr, "%02x", &cksum)) return 1;
+			if (((sum & 255) + (cksum & 255)) & 255) return 1;
+			extended_addr = i << 4;
+			//printf("ext addr = %05X\n", extended_addr);
+		}
+		if (code == 4 && len == 2) {
+			if (!sscanf(ptr, "%04x", &i)) return 1;
+			ptr += 4;
+			sum += ((i >> 8) & 255) + (i & 255);
+        		if (!sscanf(ptr, "%02x", &cksum)) return 1;
+			if (((sum & 255) + (cksum & 255)) & 255) return 1;
+			extended_addr = i << 16;
+			//printf("ext addr = %08X\n", extended_addr);
+		}
+		return 1;	// non-data line
+	}
+	byte_count += len;
+        while (num != len) {
+                if (sscanf(ptr, "%02x", &i) != 1) return 0;
+		i &= 255;
+		firmware_image[addr + extended_addr + num] = i;
+		firmware_mask[addr + extended_addr + num] = 1;
+                ptr += 2;
+                sum += i;
+                (num)++;
+                if (num >= 256) return 0;
+        }
+        if (!sscanf(ptr, "%02x", &cksum)) return 0;
+        if (((sum & 255) + (cksum & 255)) & 255) return 0; /* checksum error */
+        return 1;
+}
+
+int ihex_bytes_within_range(int begin, int end)
+{
+	int i;
+
+	if (begin < 0 || begin >= MAX_MEMORY_SIZE ||
+	   end < 0 || end >= MAX_MEMORY_SIZE) {
+		return 0;
+	}
+	for (i=begin; i<=end; i++) {
+		if (firmware_mask[i]) return 1;
+	}
+	return 0;
+}
+
+void ihex_get_data(int addr, int len, unsigned char *bytes)
+{
+	int i;
+
+	if (addr < 0 || len < 0 || addr + len >= MAX_MEMORY_SIZE) {
+		for (i=0; i<len; i++) {
+			bytes[i] = 255;
+		}
+		return;
+	}
+	for (i=0; i<len; i++) {
+		if (firmware_mask[addr]) {
+			bytes[i] = firmware_image[addr];
+		} else {
+			bytes[i] = 255;
+		}
+		addr++;
+	}
+}
+
+/****************************************************************/
+/*                                                              */
+/*                       Misc Functions                         */
+/*                                                              */
+/****************************************************************/
+
+int printf_verbose(const char *format, ...)
+{
+	va_list ap;
+	int r;
+
+	va_start(ap, format);
+	if (verbose) {
+		r = vprintf(format, ap);
+		fflush(stdout);
+		return r;
+	}
+	return 0;
+}
+
+void delay(double seconds)
+{
+	#ifdef USE_WIN32
+	sleep(seconds * 1000.0);
+	#else
+	usleep(seconds * 1000000.0);
+	#endif
+}
+
+void die(const char *str, ...)
+{
+	va_list  ap;
+
+	va_start(ap, str);
+	vfprintf(stderr, str, ap);
+	fprintf(stderr, "\n");
+	exit(1);
+}
+
+#if defined USE_WIN32
+#define strcasecmp stricmp
+#endif
+
+void parse_options(int argc, char **argv)
+{
+	int i;
+	const char *arg;
+
+	for (i=1; i<argc; i++) {
+		arg = argv[i];
+
+		if (*arg == '-') {
+			if (strcmp(arg, "-w") == 0) {
+				wait_for_device_to_appear = 1;
+			} else if (strcmp(arg, "-r") == 0) {
+				hard_reboot_device = 1;
+			} else if (strcmp(arg, "-n") == 0) {
+				reboot_after_programming = 0;
+			} else if (strcmp(arg, "-v") == 0) {
+				verbose = 1;
+			} else if (strncmp(arg, "-mmcu=", 6) == 0) {
+				arg += 6;
+
+				if (strncmp(arg, "at90usb", 7) == 0) {
+					arg += 7;
+				} else if (strncmp(arg, "atmega", 6) == 0) {
+					arg += 6;
+				} else {
+					die("Unknown MCU type\n");
+				}
+
+				if (strncmp(arg, "128", 3) == 0) {
+					code_size  = 128 * 1024;
+					block_size = 256;
+				} else if (strncmp(arg, "64", 2) == 0) {
+					code_size  = 64 * 1024;
+					block_size = 256;
+				} else if (strncmp(arg, "32", 2) == 0) {
+					code_size  = 32 * 1024;
+					block_size = 128;
+				} else if (strncmp(arg, "16", 2) == 0) {
+					code_size  = 16 * 1024;
+					block_size = 128;
+				} else if (strncmp(arg, "8", 1) == 0) {
+					code_size  = 8 * 1024;
+					block_size = 128;
+				} else {
+					die("Unknown MCU type\n");
+				}
+			}
+		} else {
+			filename = argv[i];
+		}
+	}
+}
+

--- a/keymapper/easykeymap/exttools/avrdude.conf
+++ b/keymapper/easykeymap/exttools/avrdude.conf
@@ -1,0 +1,14359 @@
+# $Id: avrdude.conf.in 1236 2013-09-16 19:40:15Z joerg_wunsch $ -*- text -*-
+#
+# AVRDUDE Configuration File
+#
+# This file contains configuration data used by AVRDUDE which describes
+# the programming hardware pinouts and also provides part definitions.
+# AVRDUDE's "-C" command line option specifies the location of the
+# configuration file.  The "-c" option names the programmer configuration
+# which must match one of the entry's "id" parameter.  The "-p" option
+# identifies which part AVRDUDE is going to be programming and must match
+# one of the parts' "id" parameter.
+#
+# Possible entry formats are:
+#
+#   programmer
+#       parent <id>                                 # optional parent
+#       id       = <id1> [, <id2> [, <id3>] ...] ;  # <idN> are quoted strings
+#       desc     = <description> ;                  # quoted string
+#       type     = <type>;                          # programmer type, quoted string
+#                          # supported programmer types can be listed by "-c ?type"
+#       connection_type = parallel | serial | usb
+#       baudrate = <num> ;                          # baudrate for avr910-programmer
+#       vcc      = <num1> [, <num2> ... ] ;         # pin number(s)
+#       buff     = <num1> [, <num2> ... ] ;         # pin number(s)
+#       reset    = <num> ;                          # pin number
+#       sck      = <num> ;                          # pin number
+#       mosi     = <num> ;                          # pin number
+#       miso     = <num> ;                          # pin number
+#       errled   = <num> ;                          # pin number
+#       rdyled   = <num> ;                          # pin number
+#       pgmled   = <num> ;                          # pin number
+#       vfyled   = <num> ;                          # pin number
+#       usbvid   = <hexnum>;                        # USB VID (Vendor ID)
+#       usbpid   = <hexnum>;                        # USB PID (Product ID)
+#       usbdev   = <interface>;                     # USB interface or other device info 
+#       usbvendor = <vendorname>;                   # USB Vendor Name
+#       usbproduct = <productname>;                 # USB Product Name
+#       usbsn    = <serialno>;                      # USB Serial Number
+#
+#        To invert a bit, use = ~ <num>, the spaces are important.
+#        For a pin list all pins must be inverted.
+#        A single pin can be specified as usual = ~ <num>, for lists
+#        specify it as follows = ~ ( <num> [, <num2> ... ] ) .
+#     ;
+#
+#   part
+#       id               = <id> ;                 # quoted string
+#       desc             = <description> ;        # quoted string
+#       has_jtag         = <yes/no> ;             # part has JTAG i/f
+#       has_debugwire    = <yes/no> ;             # part has debugWire i/f
+#       has_pdi          = <yes/no> ;             # part has PDI i/f
+#       has_tpi          = <yes/no> ;             # part has TPI i/f
+#       devicecode       = <num> ;            # deprecated, use stk500_devcode
+#       stk500_devcode   = <num> ;                # numeric
+#       avr910_devcode   = <num> ;                # numeric
+#       signature        = <num> <num> <num> ;    # signature bytes
+#       chip_erase_delay = <num> ;                # micro-seconds
+#       reset            = dedicated | io;
+#       retry_pulse      = reset | sck;
+#       pgm_enable       = <instruction format> ;
+#       chip_erase       = <instruction format> ;
+#       chip_erase_delay = <num> ;                # chip erase delay (us)
+#       # STK500 parameters (parallel programming IO lines)
+#       pagel            = <num> ;                # pin name in hex, i.e., 0xD7
+#       bs2              = <num> ;                # pin name in hex, i.e., 0xA0
+#       serial           = <yes/no> ;             # can use serial downloading
+#       parallel         = <yes/no/pseudo>;       # can use par. programming
+#       # STK500v2 parameters, to be taken from Atmel's XML files
+#       timeout          = <num> ;
+#       stabdelay        = <num> ;
+#       cmdexedelay      = <num> ;
+#       synchloops       = <num> ;
+#       bytedelay        = <num> ;
+#       pollvalue        = <num> ;
+#       pollindex        = <num> ;
+#       predelay         = <num> ;
+#       postdelay        = <num> ;
+#       pollmethod       = <num> ;
+#       mode             = <num> ;
+#       delay            = <num> ;
+#       blocksize        = <num> ;
+#       readsize         = <num> ;
+#       hvspcmdexedelay  = <num> ;
+#       # STK500v2 HV programming parameters, from XML
+#       pp_controlstack  = <num>, <num>, ...;   # PP only
+#       hvsp_controlstack = <num>, <num>, ...;  # HVSP only
+#       hventerstabdelay = <num>;
+#       progmodedelay    = <num>;               # PP only
+#       latchcycles      = <num>;
+#       togglevtg        = <num>;
+#       poweroffdelay    = <num>;
+#       resetdelayms     = <num>;
+#       resetdelayus     = <num>;
+#       hvleavestabdelay = <num>;
+#       resetdelay       = <num>;
+#       synchcycles      = <num>;               # HVSP only
+#       chiperasepulsewidth = <num>;            # PP only
+#       chiperasepolltimeout = <num>;
+#       chiperasetime    = <num>;               # HVSP only
+#       programfusepulsewidth = <num>;          # PP only
+#       programfusepolltimeout = <num>;
+#       programlockpulsewidth = <num>;          # PP only
+#       programlockpolltimeout = <num>;
+#       # JTAG ICE mkII parameters, also from XML files
+#       allowfullpagebitstream = <yes/no> ;
+#       enablepageprogramming = <yes/no> ;
+#       idr              = <num> ;                # IO addr of IDR (OCD) reg.
+#       rampz            = <num> ;                # IO addr of RAMPZ reg.
+#       spmcr            = <num> ;                # mem addr of SPMC[S]R reg.
+#       eecr             = <num> ;                # mem addr of EECR reg.
+#                                                 # (only when != 0x3c)
+#       is_at90s1200     = <yes/no> ;             # AT90S1200 part
+#       is_avr32         = <yes/no> ;             # AVR32 part
+#
+#       memory <memtype>
+#           paged           = <yes/no> ;          # yes / no
+#           size            = <num> ;             # bytes
+#           page_size       = <num> ;             # bytes
+#           num_pages       = <num> ;             # numeric
+#           min_write_delay = <num> ;             # micro-seconds
+#           max_write_delay = <num> ;             # micro-seconds
+#           readback_p1     = <num> ;             # byte value
+#           readback_p2     = <num> ;             # byte value
+#           pwroff_after_write = <yes/no> ;       # yes / no
+#           read            = <instruction format> ;
+#           write           = <instruction format> ;
+#           read_lo         = <instruction format> ;
+#           read_hi         = <instruction format> ;
+#           write_lo        = <instruction format> ;
+#           write_hi        = <instruction format> ;
+#           loadpage_lo     = <instruction format> ;
+#           loadpage_hi     = <instruction format> ;
+#           writepage       = <instruction format> ;
+#         ;
+#     ;
+#
+# If any of the above parameters are not specified, the default value
+# of 0 is used for numerics or the empty string ("") for string
+# values.  If a required parameter is left empty, AVRDUDE will
+# complain.
+#
+# Parts can also inherit parameters from previously defined parts
+# using the following syntax. In this case specified integer and 
+# string values override parameter values from the parent part. New 
+# memory definitions are added to the definitions inherited from the 
+# parent.
+#
+#   part parent <id>                              # quoted string
+#       id               = <id> ;                 # quoted string
+#       <any set of other parameters from the list above>
+#     ;
+#
+# NOTES:
+#   * 'devicecode' is the device code used by the STK500 (see codes 
+#       listed below)
+#   * Not all memory types will implement all instructions.
+#   * AVR Fuse bits and Lock bits are implemented as a type of memory.
+#   * Example memory types are:
+#       "flash", "eeprom", "fuse", "lfuse" (low fuse), "hfuse" (high
+#       fuse), "signature", "calibration", "lock"
+#   * The memory type specified on the avrdude command line must match
+#     one of the memory types defined for the specified chip.
+#   * The pwroff_after_write flag causes avrdude to attempt to
+#     power the device off and back on after an unsuccessful write to
+#     the affected memory area if VCC programmer pins are defined.  If
+#     VCC pins are not defined for the programmer, a message
+#     indicating that the device needs a power-cycle is printed out.
+#     This flag was added to work around a problem with the
+#     at90s4433/2333's; see the at90s4433 errata at:
+#
+#         http://www.atmel.com/dyn/resources/prod_documents/doc1280.pdf
+#
+# INSTRUCTION FORMATS
+#
+#    Instruction formats are specified as a comma seperated list of
+#    string values containing information (bit specifiers) about each
+#    of the 32 bits of the instruction.  Bit specifiers may be one of
+#    the following formats:
+#
+#       '1'  = the bit is always set on input as well as output
+#
+#       '0'  = the bit is always clear on input as well as output
+#
+#       'x'  = the bit is ignored on input and output
+#
+#       'a'  = the bit is an address bit, the bit-number matches this bit
+#              specifier's position within the current instruction byte
+#
+#       'aN' = the bit is the Nth address bit, bit-number = N, i.e., a12
+#              is address bit 12 on input, a0 is address bit 0.
+#
+#       'i'  = the bit is an input data bit
+#
+#       'o'  = the bit is an output data bit
+#
+#    Each instruction must be composed of 32 bit specifiers.  The
+#    instruction specification closely follows the instruction data
+#    provided in Atmel's data sheets for their parts.
+#
+# See below for some examples.
+#
+#
+# The following are STK500 part device codes to use for the
+# "devicecode" field of the part.  These came from Atmel's software
+# section avr061.zip which accompanies the application note
+# AVR061 available from:
+#
+#      http://www.atmel.com/dyn/resources/prod_documents/doc2525.pdf
+#
+
+#define ATTINY10    0x10  /* the _old_ one that never existed! */
+#define ATTINY11    0x11
+#define ATTINY12    0x12
+#define ATTINY15    0x13
+#define ATTINY13    0x14
+
+#define ATTINY22    0x20
+#define ATTINY26    0x21
+#define ATTINY28    0x22
+#define ATTINY2313  0x23
+
+#define AT90S1200   0x33
+
+#define AT90S2313   0x40
+#define AT90S2323   0x41
+#define AT90S2333   0x42
+#define AT90S2343   0x43
+
+#define AT90S4414   0x50
+#define AT90S4433   0x51
+#define AT90S4434   0x52
+#define ATMEGA48    0x59
+
+#define AT90S8515   0x60
+#define AT90S8535   0x61
+#define AT90C8534   0x62
+#define ATMEGA8515  0x63
+#define ATMEGA8535  0x64
+
+#define ATMEGA8     0x70
+#define ATMEGA88    0x73
+#define ATMEGA168   0x86
+
+#define ATMEGA161   0x80
+#define ATMEGA163   0x81
+#define ATMEGA16    0x82
+#define ATMEGA162   0x83
+#define ATMEGA169   0x84
+
+#define ATMEGA323   0x90
+#define ATMEGA32    0x91
+
+#define ATMEGA64    0xA0
+
+#define ATMEGA103   0xB1
+#define ATMEGA128   0xB2
+#define AT90CAN128  0xB3
+#define AT90CAN64   0xB3
+#define AT90CAN32   0xB3
+
+#define AT86RF401   0xD0
+
+#define AT89START   0xE0
+#define AT89S51	    0xE0
+#define AT89S52	    0xE1
+
+# The following table lists the devices in the original AVR910
+# appnote:
+# |Device |Signature | Code |
+# +-------+----------+------+
+# |tiny12 | 1E 90 05 | 0x55 |
+# |tiny15 | 1E 90 06 | 0x56 |
+# |       |          |      |
+# | S1200 | 1E 90 01 | 0x13 |
+# |       |          |      |
+# | S2313 | 1E 91 01 | 0x20 |
+# | S2323 | 1E 91 02 | 0x48 |
+# | S2333 | 1E 91 05 | 0x34 |
+# | S2343 | 1E 91 03 | 0x4C |
+# |       |          |      |
+# | S4414 | 1E 92 01 | 0x28 |
+# | S4433 | 1E 92 03 | 0x30 |
+# | S4434 | 1E 92 02 | 0x6C |
+# |       |          |      |
+# | S8515 | 1E 93 01 | 0x38 |
+# | S8535 | 1E 93 03 | 0x68 |
+# |       |          |      |
+# |mega32 | 1E 95 01 | 0x72 |
+# |mega83 | 1E 93 05 | 0x65 |
+# |mega103| 1E 97 01 | 0x41 |
+# |mega161| 1E 94 01 | 0x60 |
+# |mega163| 1E 94 02 | 0x64 |
+
+# Appnote AVR109 also has a table of AVR910 device codes, which
+# lists:
+# dev         avr910   signature
+# ATmega8     0x77     0x1E 0x93 0x07
+# ATmega8515  0x3B     0x1E 0x93 0x06
+# ATmega8535  0x6A     0x1E 0x93 0x08
+# ATmega16    0x75     0x1E 0x94 0x03
+# ATmega162   0x63     0x1E 0x94 0x04
+# ATmega163   0x66     0x1E 0x94 0x02
+# ATmega169   0x79     0x1E 0x94 0x05
+# ATmega32    0x7F     0x1E 0x95 0x02
+# ATmega323   0x73     0x1E 0x95 0x01
+# ATmega64    0x46     0x1E 0x96 0x02
+# ATmega128   0x44     0x1E 0x97 0x02
+#
+# These codes refer to "BOOT" device codes which are apparently
+# different than standard device codes, for whatever reasons
+# (often one above the standard code).
+
+# There are several extended versions of AVR910 implementations around
+# in the Internet.  These add the following codes (only devices that
+# actually exist are listed):
+
+# ATmega8515	0x3A
+# ATmega128	0x43
+# ATmega64	0x45
+# ATtiny26	0x5E
+# ATmega8535	0x69
+# ATmega32	0x72
+# ATmega16	0x74
+# ATmega8	0x76
+# ATmega169	0x78
+
+#
+# Overall avrdude defaults; suitable for ~/.avrduderc
+#
+default_parallel   = "lpt1";
+default_serial     = "com1";
+# default_bitclock = 2.5;
+
+# Turn off safemode by default
+#default_safemode  = no;
+
+
+#
+# PROGRAMMER DEFINITIONS
+#
+
+# http://wiring.org.co/
+# Basically STK500v2 protocol, with some glue to trigger the
+# bootloader.
+programmer
+  id    = "wiring";
+  desc  = "Wiring";
+  type  = "wiring";
+  connection_type = serial;
+;
+
+programmer
+  id    = "arduino";
+  desc  = "Arduino";
+  type  = "arduino";
+  connection_type = serial;
+;
+# this will interface with the chips on these programmers:
+#
+# http://real.kiev.ua/old/avreal/en/adapters
+# http://www.amontec.com/jtagkey.shtml, jtagkey-tiny.shtml
+# http://www.olimex.com/dev/arm-usb-ocd.html, arm-usb-tiny.html
+# http://www.ethernut.de/en/hardware/turtelizer/index.html
+# http://elk.informatik.fh-augsburg.de/hhweb/doc/openocd/usbjtag/usbjtag.html
+# http://dangerousprototypes.com/docs/FT2232_breakout_board
+# http://www.ftdichip.com/Products/Modules/DLPModules.htm,DLP-2232*,DLP-USB1232H
+# http://flashrom.org/FT2232SPI_Programmer
+# 
+# The drivers will look for a specific device and use the first one found.
+# If you have mulitple devices, then look for unique information (like SN)
+# And fill that in here.
+#
+# Note that the pin numbers for the main ISP signals (reset, sck,
+# mosi, miso) are fixed and cannot be changed, since they must match
+# the way the Multi-Protocol Synchronous Serial Engine (MPSSE) of
+# these FTDI ICs has been designed.
+
+programmer
+  id         = "avrftdi";
+  desc       = "FT2232D based generic programmer";
+  type       = "avrftdi";
+  connection_type = usb;
+  usbvid     = 0x0403;
+  usbpid     = 0x6010;
+  usbvendor  = "";
+  usbproduct = "";
+  usbdev     = "A";
+  usbsn      = "";
+#ISP-signals - lower ADBUS-Nibble (default)
+  reset  = 3;
+  sck    = 0;
+  mosi   = 1;
+  miso   = 2;
+#LED SIGNALs - higher ADBUS-Nibble
+#  errled = 4;
+#  rdyled = 5;
+#  pgmled = 6;
+#  vfyled = 7;
+#Buffer Signal - ACBUS - Nibble
+#  buff   = 8;
+;
+# This is an implementation of the above with a buffer IC (74AC244) and
+# 4 LEDs directly attached, all active low.
+programmer
+  id         = "2232HIO";
+  desc       = "FT2232H based generic programmer";
+  type       = "avrftdi";
+  connection_type = usb;
+  usbvid     = 0x0403;
+# Note: This PID is reserved for generic H devices and 
+# should be programmed into the EEPROM
+#  usbpid     = 0x8A48;
+  usbpid     = 0x6010;
+  usbdev     = "A";
+  usbvendor  = "";
+  usbproduct = "";
+  usbsn      = "";
+#ISP-signals 
+  reset  = 3;
+  sck    = 0;
+  mosi   = 1;
+  miso   = 2;
+  buff   = ~4;
+#LED SIGNALs 
+  errled = ~ 11;
+  rdyled = ~ 14;
+  pgmled = ~ 13;
+  vfyled = ~ 12;
+;
+
+#The FT4232H can be treated as FT2232H, but it has a different USB
+#device ID of 0x6011.
+programmer parent "avrftdi"
+  id         = "4232h";
+  desc       = "FT4232H based generic programmer";
+  usbpid     = 0x6011;
+;
+
+programmer
+  id         = "jtagkey";
+  desc       = "Amontec JTAGKey, JTAGKey-Tiny and JTAGKey2";
+  type       = "avrftdi";
+  connection_type = usb;
+  usbvid     = 0x0403;
+# Note: This PID is used in all JTAGKey variants
+  usbpid     = 0xCFF8;
+  usbdev     = "A";
+  usbvendor  = "";
+  usbproduct = "";
+  usbsn      = "";
+#ISP-signals => 20 - Pin connector on JTAGKey
+  reset  = 3; # TMS 7 violet
+  sck    = 0; # TCK 9 white
+  mosi   = 1; # TDI 5 green
+  miso   = 2; # TDO 13 orange
+  buff   = ~4;
+# VTG           VREF 1 brown with red tip
+# GND           GND 20 black
+# The colors are on the 20 pin breakout cable
+# from Amontec
+;
+
+# On the adapter you can read "O-Link". On the PCB is printed "OpenJTAG v3.1"
+# You can find it as "OpenJTAG ARM JTAG USB" in the internet. 
+# (But there are also several projects called Open JTAG, eg. 
+# http://www.openjtag.org, which are completely different.)
+#   http://www.100ask.net/shop/english.html (website seems to be outdated)
+#   http://item.taobao.com/item.htm?id=1559277013
+#   http://www.micro4you.com/store/openjtag-arm-jtag-usb.html (schematics!)
+# some other sources which call it O-Link
+#   http://www.andahammer.com/olink/
+#   http://www.developmentboard.net/31-o-link-debugger.html
+#   http://armwerks.com/catalog/o-link-debugger-copy/
+# or just have a look at ebay ...
+# It is basically the same entry as jtagkey with different usb ids.
+programmer parent "jtagkey"
+  id         = "o-link";
+  desc       = "O-Link, OpenJTAG from www.100ask.net";
+  usbvid     = 0x1457;
+  usbpid     = 0x5118;
+  usbvendor  = "www.100ask.net";
+  usbproduct = "USB<=>JTAG&RS232";
+;
+
+# http://wiki.openmoko.org/wiki/Debug_Board_v3
+programmer
+  id    = "openmoko";
+  desc  = "Openmoko debug board (v3)";
+  type  = "avrftdi";
+  usbvid     = 0x1457;
+  usbpid    = 0x5118;
+  usbdev = "A";
+  usbvendor  = "";
+  usbproduct = "";
+  usbsn      = "";
+  reset  = 3; # TMS 7
+  sck    = 0; # TCK 9
+  mosi   = 1; # TDI 5
+  miso   = 2; # TDO 13
+;
+
+# Only Rev. A boards.
+# Schematic and user manual: http://www.cs.put.poznan.pl/wswitala/download/pdf/811EVBK.pdf
+programmer
+  id         = "lm3s811";
+  desc       = "Luminary Micro LM3S811 Eval Board (Rev. A)";
+  type       = "avrftdi";
+  connection_type = usb;
+  usbvid     = 0x0403;
+  usbpid     = 0xbcd9;
+  usbvendor  = "LMI";
+  usbproduct = "LM3S811 Evaluation Board";
+  usbdev     = "A";
+  usbsn      = "";
+#ISP-signals - lower ACBUS-Nibble (default)
+  reset  = 3;
+  sck    = 0;
+  mosi   = 1;
+  miso   = 2;
+# Enable correct buffers
+  buff   = 7;
+;
+
+programmer
+  id    = "avrisp";
+  desc  = "Atmel AVR ISP";
+  type  = "stk500";
+  connection_type = serial;
+;
+
+programmer
+  id    = "avrispv2";
+  desc  = "Atmel AVR ISP V2";
+  type  =  "stk500v2";
+  connection_type = serial;
+;
+
+programmer
+  id    = "avrispmkII";
+  desc  = "Atmel AVR ISP mkII";
+  type  =  "stk500v2";
+  connection_type = usb;
+;
+
+programmer parent "avrispmkII"
+  id    = "avrisp2";
+;
+
+programmer
+  id    = "buspirate";
+  desc  = "The Bus Pirate";
+  type  = "buspirate";
+  connection_type = serial;
+;
+
+programmer
+  id    = "buspirate_bb";
+  desc  = "The Bus Pirate (bitbang interface, supports TPI)";
+  type  = "buspirate_bb";
+  connection_type = serial;
+  # pins are bits in bitbang byte (numbers are 87654321)
+  # 1|POWER|PULLUP|AUX|MOSI|CLK|MISO|CS
+  reset  = 1;
+  sck    = 3;
+  mosi   = 4;
+  miso   = 2;
+  #vcc    = 7; This is internally set independent of this setting.
+;
+
+# This is supposed to be the "default" STK500 entry.
+# Attempts to select the correct firmware version
+# by probing for it.  Better use one of the entries
+# below instead.
+programmer
+  id    = "stk500";
+  desc  = "Atmel STK500";
+  type  = "stk500generic";
+  connection_type = serial;
+;
+
+programmer
+  id    = "stk500v1";
+  desc  = "Atmel STK500 Version 1.x firmware";
+  type  = "stk500";
+  connection_type = serial;
+;
+
+programmer
+  id    = "mib510";
+  desc  = "Crossbow MIB510 programming board";
+  type  = "stk500";
+  connection_type = serial;
+;
+
+programmer
+  id    = "stk500v2";
+  desc  = "Atmel STK500 Version 2.x firmware";
+  type  = "stk500v2";
+  connection_type = serial;
+;
+
+programmer
+  id    = "stk500pp";
+  desc  = "Atmel STK500 V2 in parallel programming mode";
+  type  = "stk500pp";
+  connection_type = serial;
+;
+
+programmer
+  id    = "stk500hvsp";
+  desc  = "Atmel STK500 V2 in high-voltage serial programming mode";
+  type  = "stk500hvsp";
+  connection_type = serial;
+;
+
+programmer
+  id    = "stk600";
+  desc  = "Atmel STK600";
+  type  = "stk600";
+  connection_type = usb;
+;
+
+programmer
+  id    = "stk600pp";
+  desc  = "Atmel STK600 in parallel programming mode";
+  type  = "stk600pp";
+  connection_type = usb;
+;
+
+programmer
+  id    = "stk600hvsp";
+  desc  = "Atmel STK600 in high-voltage serial programming mode";
+  type  = "stk600hvsp";
+  connection_type = usb;
+;
+
+programmer
+  id    = "avr910";
+  desc  = "Atmel Low Cost Serial Programmer";
+  type  = "avr910";
+  connection_type = serial;
+;
+
+programmer
+  id    = "ft245r";
+  desc  = "FT245R Synchronous BitBang";
+  type  = "ftdi_syncbb";
+  connection_type = usb;
+  miso  = 1; # D1
+  sck   = 0; # D0
+  mosi  = 2; # D2
+  reset = 4; # D4
+;
+
+programmer
+  id    = "ft232r";
+  desc  = "FT232R Synchronous BitBang";
+  type  = "ftdi_syncbb";
+  connection_type = usb;
+  miso  = 1;  # RxD
+  sck   = 0;  # RTS
+  mosi  = 2;  # TxD
+  reset = 4;  # DTR
+;
+
+# see http://www.bitwizard.nl/wiki/index.php/FTDI_ATmega
+programmer
+  id    = "bwmega";
+  desc  = "BitWizard ftdi_atmega builtin programmer";
+  type  = "ftdi_syncbb";
+  connection_type = usb;
+  miso  = 5;  # DSR
+  sck   = 6;  # DCD
+  mosi  = 3;  # CTS
+  reset = 7;  # RI
+;
+
+# see http://www.geocities.jp/arduino_diecimila/bootloader/index_en.html
+# Note: pins are numbered from 1!
+programmer
+  id    = "arduino-ft232r";
+  desc  = "Arduino: FT232R connected to ISP";
+  type  = "ftdi_syncbb";
+  connection_type = usb;
+  miso  = 3;  # CTS X3(1)
+  sck   = 5;  # DSR X3(2)
+  mosi  = 6;  # DCD X3(3)
+  reset = 7;  # RI  X3(4)
+;
+
+# website mentioned above uses this id
+programmer parent "arduino-ft232r"
+  id    = "diecimila";
+  desc  = "alias for arduino-ft232r";
+;
+
+programmer
+  id    = "usbasp";
+  desc  = "USBasp, http://www.fischl.de/usbasp/";
+  type  = "usbasp";
+  connection_type = usb;
+  usbvid     = 0x16C0; # VOTI
+  usbpid     = 0x05DC; # Obdev's free shared PID
+  usbvendor  = "www.fischl.de";
+  usbproduct = "USBasp";
+
+  # following variants are autodetected for id "usbasp"
+
+  # original usbasp from fischl.de
+  # see above "usbasp"
+
+  # old usbasp from fischl.de
+  #usbvid     = 0x03EB; # ATMEL
+  #usbpid     = 0xC7B4; # (unoffical) USBasp
+  #usbvendor  = "www.fischl.de";
+  #usbproduct = "USBasp";
+
+  # NIBObee (only if -P nibobee is given on command line)
+  # see below "nibobee"
+;
+
+programmer
+  id    = "nibobee";
+  desc  = "NIBObee";
+  type  = "usbasp";
+  connection_type = usb;
+  usbvid     = 0x16C0; # VOTI
+  usbpid     = 0x092F; # NIBObee PID
+  usbvendor  = "www.nicai-systems.com";
+  usbproduct = "NIBObee";
+;
+
+programmer
+  id    = "usbasp-clone";
+  desc  = "Any usbasp clone with correct VID/PID";
+  type  = "usbasp";
+  connection_type = usb;
+  usbvid    = 0x16C0; # VOTI
+  usbpid    = 0x05DC; # Obdev's free shared PID
+  #usbvendor  = "";
+  #usbproduct = "";
+;
+
+programmer
+  id    = "usbtiny";
+  desc  = "USBtiny simple USB programmer, http://www.ladyada.net/make/usbtinyisp/";
+  type  = "usbtiny";
+  connection_type = usb;
+  usbvid     = 0x1781;
+  usbpid     = 0x0c9f;
+;
+
+programmer
+  id    = "arduinoisp";
+  desc  = " ";
+  type  = "usbtiny";
+  connection_type = usb;
+  usbvid     = 0x2341;
+  usbpid     = 0x0049;
+;
+
+programmer
+  id    = "butterfly";
+  desc  = "Atmel Butterfly Development Board";
+  type  = "butterfly";
+  connection_type = serial;
+;
+
+programmer
+  id    = "avr109";
+  desc  = "Atmel AppNote AVR109 Boot Loader";
+  type  = "butterfly";
+  connection_type = serial;
+;
+
+programmer
+  id    = "avr911";
+  desc  = "Atmel AppNote AVR911 AVROSP";
+  type  = "butterfly";
+  connection_type = serial;
+;
+ 
+# suggested in http://forum.mikrokopter.de/topic-post48317.html
+programmer
+  id    = "mkbutterfly";
+  desc  = "Mikrokopter.de Butterfly";
+  type  = "butterfly_mk";
+  connection_type = serial;
+;
+
+programmer parent "mkbutterfly"
+  id    = "butterfly_mk";
+;
+
+programmer
+  id    = "jtagmkI";
+  desc  = "Atmel JTAG ICE (mkI)";
+  baudrate = 115200;    # default is 115200
+  type  = "jtagmki";
+  connection_type = serial;
+;
+
+# easier to type
+programmer parent "jtagmkI"
+  id    = "jtag1";
+;
+
+# easier to type
+programmer parent "jtag1"
+  id    = "jtag1slow";
+  baudrate = 19200;
+;
+
+# The JTAG ICE mkII has both, serial and USB connectivity.  As it is
+# mostly used through USB these days (AVR Studio 5 only supporting it
+# that way), we make connection_type = usb the default.  Users are
+# still free to use a serial port with the -P option.
+
+programmer
+  id    = "jtagmkII";
+  desc  = "Atmel JTAG ICE mkII";
+  baudrate = 19200;    # default is 19200
+  type  = "jtagmkii";
+  connection_type = usb;
+;
+
+# easier to type
+programmer parent "jtagmkII"
+  id    = "jtag2slow";
+;
+
+# JTAG ICE mkII @ 115200 Bd
+programmer parent "jtag2slow"
+  id    = "jtag2fast";
+  baudrate = 115200;
+;
+
+# make the fast one the default, people will love that
+programmer parent "jtag2fast"
+  id    = "jtag2";
+;
+
+# JTAG ICE mkII in ISP mode
+programmer
+  id    = "jtag2isp";
+  desc  = "Atmel JTAG ICE mkII in ISP mode";
+  baudrate = 115200;
+  type  = "jtagmkii_isp";
+  connection_type = usb;
+;
+
+# JTAG ICE mkII in debugWire mode
+programmer
+  id    = "jtag2dw";
+  desc  = "Atmel JTAG ICE mkII in debugWire mode";
+  baudrate = 115200;
+  type  = "jtagmkii_dw";
+  connection_type = usb;
+;
+
+# JTAG ICE mkII in AVR32 mode
+programmer
+  id    = "jtagmkII_avr32";
+  desc  = "Atmel JTAG ICE mkII im AVR32 mode";
+  baudrate = 115200;
+  type  = "jtagmkii_avr32";
+  connection_type = usb;
+;
+
+# JTAG ICE mkII in AVR32 mode
+programmer
+  id    = "jtag2avr32";
+  desc  = "Atmel JTAG ICE mkII im AVR32 mode";
+  baudrate = 115200;
+  type  = "jtagmkii_avr32";
+  connection_type = usb;
+;
+
+# JTAG ICE mkII in PDI mode
+programmer
+  id    = "jtag2pdi";
+  desc  = "Atmel JTAG ICE mkII PDI mode";
+  baudrate = 115200;
+  type  = "jtagmkii_pdi";
+  connection_type = usb;
+;
+
+# AVR Dragon in JTAG mode
+programmer
+  id    = "dragon_jtag";
+  desc  = "Atmel AVR Dragon in JTAG mode";
+  baudrate = 115200;
+  type  = "dragon_jtag";
+  connection_type = usb;
+;
+
+# AVR Dragon in ISP mode
+programmer
+  id    = "dragon_isp";
+  desc  = "Atmel AVR Dragon in ISP mode";
+  baudrate = 115200;
+  type  = "dragon_isp";
+  connection_type = usb;
+;
+
+# AVR Dragon in PP mode
+programmer
+  id    = "dragon_pp";
+  desc  = "Atmel AVR Dragon in PP mode";
+  baudrate = 115200;
+  type  = "dragon_pp";
+  connection_type = usb;
+;
+
+# AVR Dragon in HVSP mode
+programmer
+  id    = "dragon_hvsp";
+  desc  = "Atmel AVR Dragon in HVSP mode";
+  baudrate = 115200;
+  type  = "dragon_hvsp";
+  connection_type = usb;
+;
+
+# AVR Dragon in debugWire mode
+programmer
+  id    = "dragon_dw";
+  desc  = "Atmel AVR Dragon in debugWire mode";
+  baudrate = 115200;
+  type  = "dragon_dw";
+  connection_type = usb;
+;
+
+# AVR Dragon in PDI mode
+programmer
+  id    = "dragon_pdi";
+  desc  = "Atmel AVR Dragon in PDI mode";
+  baudrate = 115200;
+  type  = "dragon_pdi";
+  connection_type = usb;
+;
+
+programmer
+  id    = "jtag3";
+  desc  = "Atmel AVR JTAGICE3 in JTAG mode";
+  type  = "jtagice3";
+  connection_type = usb;
+;
+
+programmer
+  id    = "jtag3pdi";
+  desc  = "Atmel AVR JTAGICE3 in PDI mode";
+  type  = "jtagice3_pdi";
+  connection_type = usb;
+;
+
+programmer
+  id    = "jtag3dw";
+  desc  = "Atmel AVR JTAGICE3 in debugWIRE mode";
+  type  = "jtagice3_dw";
+  connection_type = usb;
+;
+
+programmer
+  id    = "jtag3isp";
+  desc  = "Atmel AVR JTAGICE3 in ISP mode";
+  type  = "jtagice3_isp";
+  connection_type = usb;
+;
+
+
+programmer
+  id    = "pavr";
+  desc  = "Jason Kyle's pAVR Serial Programmer";
+  type  = "avr910";
+  connection_type = serial;
+;
+
+programmer
+  id    = "pickit2";
+  desc  = "MicroChip's PICkit2 Programmer";
+  type  = "pickit2";
+  connection_type = usb;
+;
+
+# Parallel port programmers.
+
+programmer
+  id    = "bsd";
+  desc  = "Brian Dean's Programmer, http://www.bsdhome.com/avrdude/";
+  type  = "par";
+  connection_type = parallel;
+  vcc   = 2, 3, 4, 5;
+  reset = 7;
+  sck   = 8;
+  mosi  = 9;
+  miso  = 10;
+;
+
+programmer
+  id    = "stk200";
+  desc  = "STK200";
+  type  = "par";
+  connection_type = parallel;
+  buff  = 4, 5;
+  sck   = 6;
+  mosi  = 7;
+  reset = 9;
+  miso  = 10;
+;
+
+# The programming dongle used by the popular Ponyprog
+# utility.  It is almost similar to the STK200 one,
+# except that there is a LED indicating that the
+# programming is currently in progress.
+
+programmer parent "stk200"
+  id    = "pony-stk200";
+  desc  = "Pony Prog STK200";
+  pgmled = 8; 
+;
+
+programmer
+  id    = "dt006";
+  desc  = "Dontronics DT006";
+  type  = "par";
+  connection_type = parallel;
+  reset = 4;
+  sck   = 5;
+  mosi  = 2;
+  miso  = 11;
+;
+
+programmer parent "dt006"
+  id    = "bascom";
+  desc  = "Bascom SAMPLE programming cable";
+;
+
+programmer
+  id     = "alf";
+  desc   = "Nightshade ALF-PgmAVR, http://nightshade.homeip.net/";
+  type   = "par";
+  connection_type = parallel;
+  vcc    = 2, 3, 4, 5;
+  buff   = 6;
+  reset  = 7;
+  sck    = 8;
+  mosi   = 9;
+  miso   = 10;
+  errled = 1;
+  rdyled = 14;
+  pgmled = 16;
+  vfyled = 17;
+;
+
+programmer
+  id    = "sp12";
+  desc  = "Steve Bolt's Programmer";
+  type  = "par";
+  connection_type = parallel;
+  vcc   = 4,5,6,7,8;
+  reset = 3;
+  sck   = 2;
+  mosi  = 9;
+  miso  = 11;
+;
+
+programmer
+  id     = "picoweb";
+  desc   = "Picoweb Programming Cable, http://www.picoweb.net/";
+  type   = "par";
+  connection_type = parallel;
+  reset  = 2;
+  sck    = 3;
+  mosi   = 4;
+  miso   = 13;
+;
+
+programmer
+  id    = "abcmini";
+  desc  = "ABCmini Board, aka Dick Smith HOTCHIP";
+  type  = "par";
+  connection_type = parallel;
+  reset = 4;
+  sck   = 3;
+  mosi  = 2;
+  miso  = 10;
+;
+
+programmer
+  id    = "futurlec";
+  desc  = "Futurlec.com programming cable.";
+  type  = "par";
+  connection_type = parallel;
+  reset = 3;
+  sck   = 2;
+  mosi  = 1;
+  miso  = 10;
+;
+
+
+# From the contributor of the "xil" jtag cable:
+# The "vcc" definition isn't really vcc (the cable gets its power from
+# the programming circuit) but is necessary to switch one of the
+# buffer lines (trying to add it to the "buff" lines doesn't work in 
+# avrdude versions before 5.5j).
+# With this, TMS connects to RESET, TDI to MOSI, TDO to MISO and TCK
+# to SCK (plus vcc/gnd of course)
+programmer
+  id    = "xil";
+  desc  = "Xilinx JTAG cable";
+  type  = "par";
+  connection_type = parallel;
+  mosi  = 2;
+  sck   = 3;
+  reset = 4;
+  buff  = 5;
+  miso  = 13;
+  vcc   = 6;
+;
+
+
+programmer
+  id = "dapa";
+  desc = "Direct AVR Parallel Access cable";
+  type = "par";
+  connection_type = parallel;
+  vcc   = 3;
+  reset = 16;
+  sck = 1;
+  mosi = 2;
+  miso = 11;
+;
+
+programmer
+  id    = "atisp";
+  desc  = "AT-ISP V1.1 programming cable for AVR-SDK1 from <http://micro-research.co.th/> micro-research.co.th";
+  type  = "par";
+  connection_type = parallel;
+  reset = ~6;
+  sck   = ~8;
+  mosi  = ~7;
+  miso  = ~10;
+;
+
+programmer
+  id    = "ere-isp-avr";
+  desc  = "ERE ISP-AVR <http://www.ere.co.th/download/sch050713.pdf>";
+  type  = "par";
+  connection_type = parallel;
+  reset = ~4;
+  sck   = 3;
+  mosi  = 2;
+  miso  = 10;
+;
+
+programmer
+  id    = "blaster";
+  desc  = "Altera ByteBlaster";
+  type  = "par";
+  connection_type = parallel;
+  sck   = 2;
+  miso  = 11;
+  reset = 3;
+  mosi  = 8;
+  buff  = 14;
+;
+
+# It is almost same as pony-stk200, except vcc on pin 5 to auto
+# disconnect port (download on http://electropol.free.fr/spip/spip.php?article27)
+programmer parent "pony-stk200"
+  id    = "frank-stk200";
+  desc  = "Frank STK200";
+  buff  = ; # delete buff pin assignment
+  vcc   = 5;
+;
+
+# The AT98ISP Cable is a simple parallel dongle for AT89 family.
+# http://www.atmel.com/dyn/products/tools_card.asp?tool_id=2877
+programmer
+  id = "89isp";
+  desc = "Atmel at89isp cable";
+  type = "par";
+  connection_type = parallel;
+  reset = 17;
+  sck = 1;
+  mosi = 2;
+  miso = 10;
+;
+
+
+#This programmer bitbangs GPIO lines using the Linux sysfs GPIO interface
+#
+#To enable it set the configuration below to match the GPIO lines connected to the
+#relevant ISP header pins and uncomment the entry definition. In case you don't
+#have the required permissions to edit this system wide config file put the
+#entry in a separate <your name>.conf file and use it with -C+<your name>.conf
+#on the command line.
+#
+#To check if your avrdude build has support for the linuxgpio programmer compiled in,
+#use -c?type on the command line and look for linuxgpio in the list. If it's not available
+#you need pass the --enable-linuxgpio=yes option to configure and recompile avrdude.
+#
+#programmer
+#  id    = "linuxgpio";
+#  desc  = "Use the Linux sysfs interface to bitbang GPIO lines";
+#  type  = "linuxgpio";
+#  reset = ?;
+#  sck   = ?;
+#  mosi  = ?;
+#  miso  = ?;
+#;
+
+# some ultra cheap programmers use bitbanging on the 
+# serialport.
+#
+# PC - DB9 - Pins for RS232:
+#
+# GND   5   -- |O
+#              |   O| <-   9   RI
+# DTR   4   <- |O   |
+#              |   O| <-   8   CTS
+# TXD   3   <- |O   |
+#              |   O| ->   7   RTS
+# RXD   2   -> |O   |
+#              |   O| <-   6   DSR
+# DCD   1   -> |O
+#
+# Using RXD is currently not supported.
+# Using RI is not supported under Win32 but is supported under Posix.
+
+# serial ponyprog design (dasa2 in uisp)
+# reset=!txd sck=rts mosi=dtr miso=cts
+
+programmer
+  id    = "ponyser";
+  desc  = "design ponyprog serial, reset=!txd sck=rts mosi=dtr miso=cts";
+  type  = "serbb";
+  connection_type = serial;
+  reset = ~3;
+  sck   = 7;
+  mosi  = 4;
+  miso  = 8;
+;
+
+# Same as above, different name
+# reset=!txd sck=rts mosi=dtr miso=cts
+
+programmer parent "ponyser"
+  id    = "siprog";
+  desc  = "Lancos SI-Prog <http://www.lancos.com/siprogsch.html>";
+;
+
+# unknown (dasa in uisp)
+# reset=rts sck=dtr mosi=txd miso=cts
+
+programmer
+  id    = "dasa";
+  desc  = "serial port banging, reset=rts sck=dtr mosi=txd miso=cts";
+  type  = "serbb";
+  connection_type = serial;
+  reset = 7;
+  sck   = 4;
+  mosi  = 3;
+  miso  = 8;
+;
+
+# unknown (dasa3 in uisp)
+# reset=!dtr sck=rts mosi=txd miso=cts
+
+programmer
+  id    = "dasa3";
+  desc  = "serial port banging, reset=!dtr sck=rts mosi=txd miso=cts";
+  type  = "serbb";
+  connection_type = serial;
+  reset = ~4;
+  sck   = 7;
+  mosi  = 3;
+  miso  = 8;
+;
+
+# C2N232i (jumper configuration "auto")
+# reset=dtr sck=!rts mosi=!txd miso=!cts
+
+programmer
+  id    = "c2n232i";
+  desc  = "serial port banging, reset=dtr sck=!rts mosi=!txd miso=!cts";
+  type  = "serbb";
+  connection_type = serial;
+  reset = 4;
+  sck   = ~7;
+  mosi  = ~3;
+  miso  = ~8;
+;
+
+#
+# PART DEFINITIONS
+#
+
+#------------------------------------------------------------
+# ATtiny11
+#------------------------------------------------------------
+
+# This is an HVSP-only device.
+
+part
+    id                  = "t11";
+    desc                = "ATtiny11";
+    stk500_devcode      = 0x11;
+    signature           = 0x1e 0x90 0x04;
+    chip_erase_delay    = 20000;
+
+    timeout		= 200;
+    hvsp_controlstack     =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
+        0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
+        0x78, 0x00, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 0;
+    resetdelayus        = 50;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    memory "eeprom"
+        size            = 64;
+	blocksize	= 64;
+	readsize	= 256;
+	delay		= 5;
+    ;
+
+    memory "flash"
+        size            = 1024;
+	blocksize	= 128;
+	readsize	= 256;
+	delay		= 3;
+    ;
+
+    memory "signature"
+        size            = 3;
+    ;
+
+    memory "lock"
+        size            = 1;
+    ;
+
+    memory "calibration"
+        size            = 1;
+    ;
+
+    memory "fuse"
+        size            = 1;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny12
+#------------------------------------------------------------
+
+part
+    id                  = "t12";
+    desc                = "ATtiny12";
+    stk500_devcode      = 0x12;
+    avr910_devcode      = 0x55;
+    signature           = 0x1e 0x90 0x05;
+    chip_erase_delay    = 20000;
+    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
+        0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
+        0x78, 0x00, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    hventerstabdelay    = 100;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 0;
+    resetdelayus        = 50;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    memory "eeprom"
+        size            = 64;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
+                          "x  x a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+
+        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
+                          "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+
+	mode		= 0x04;
+	delay		= 8;
+	blocksize	= 64;
+	readsize	= 256;
+    ;
+
+    memory "flash"
+        size            = 1024;
+        min_write_delay = 4500;
+        max_write_delay = 20000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0  0  1  0   0  0  0  0",
+                          "  x  x  x  x   x  x  x a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  o  o  o  o   o  o  o  o";
+
+        read_hi         = "  0  0  1  0   1  0  0  0",
+                          "  x  x  x  x   x  x  x a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  o  o  o  o   o  o  o  o";
+
+        write_lo        = "  0  1  0  0   0  0  0  0",
+                          "  x  x  x  x   x  x  x a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        write_hi        = "  0  1  0  0   1  0  0  0",
+                          "  x  x  x  x   x  x  x a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+	mode		= 0x04;
+	delay		= 5;
+	blocksize	= 128;
+	readsize	= 256;
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+    ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
+                          "x  x  x  x   x  x  x  x    x x x x  x o o x";
+
+        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 i i 1",
+                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+    ;
+
+    memory "fuse"
+        size            = 1;
+        read            = "0  1  0  1   0  0  0  0    x x x x  x x x x",
+                          "x  x  x  x   x  x  x  x    o o o o  o o o o";
+
+        write           = "1  0  1  0   1  1  0  0    1 0 1 x  x x x x",
+                          "x  x  x  x   x  x  x  x    i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny13
+#------------------------------------------------------------
+
+part
+    id                  = "t13";
+    desc                = "ATtiny13";
+     has_debugwire = yes;
+     flash_instr   = 0xB4, 0x0E, 0x1E;
+     eeprom_instr  = 0xBB, 0xFE, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+	             0xBC, 0x0E, 0xB4, 0x0E, 0xBA, 0x0D, 0xBB, 0xBC,
+	             0x99, 0xE1, 0xBB, 0xAC;
+    stk500_devcode      = 0x14;
+    signature           = 0x1e 0x90 0x07;
+    chip_erase_delay    = 4000;
+    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    hvsp_controlstack     =
+	0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
+        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 0;
+    resetdelayus        = 90;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    ocdrev              = 0;
+
+    memory "eeprom"
+        size            = 64;
+        page_size       = 4;
+        min_write_delay = 4000;
+        max_write_delay = 4000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
+                          "x  x a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+
+        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
+                          "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  "  x   x  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 5;
+	blocksize	= 4;
+	readsize	= 256;
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 1024;
+        page_size       = 32;
+        num_pages       = 32;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0  0  1  0   0  0  0  0",
+                          "  0  0  0  0   0  0  0 a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  o  o  o  o   o  o  o  o";
+
+        read_hi         = "  0  0  1  0   1  0  0  0",
+                          "  0  0  0  0   0  0  0 a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  o  o  o  o   o  o  o  o";
+
+        loadpage_lo     = "  0  1  0  0   0  0  0  0",
+                          "  0  0  0  x   x  x  x  x",
+                          "  x  x  x  x  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        loadpage_hi     = "  0  1  0  0   1  0  0  0",
+                          "  0  0  0  x   x  x  x  x",
+                          "  x  x  x  x  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        writepage       = "  0  1  0  0   1  1  0  0",
+                          "  0  0  0  0   0  0  0 a8",
+                          " a7 a6 a5 a4   x  x  x  x",
+                          "  x  x  x  x   x  x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 32;
+	readsize	= 256;
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0    0 0 0 x  x x x x",
+                          "x  x  x  x   x  x a1 a0    o o o o  o o o o";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+
+	read            = "0  1  0  1   1  0  0  0    0 0 0 0  0 0 0 0",
+                          "x  x  x  x   x  x  x  x    x x o o  o o o o";
+
+        write           = "1  0  1  0   1  1  0  0    1 1 1 x  x x x x",
+                          "x  x  x  x   x  x  x  x    1 1 i i  i i i i";
+    ;
+
+    memory "calibration"
+        size            = 2;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                          "0  0  0  0   0  0  0 a0    o o o o  o o o o";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+      ;
+
+;
+
+
+#------------------------------------------------------------
+# ATtiny15
+#------------------------------------------------------------
+
+part
+    id                  = "t15";
+    desc                = "ATtiny15";
+    stk500_devcode      = 0x13;
+    avr910_devcode      = 0x56;
+    signature           = 0x1e 0x90 0x06;
+    chip_erase_delay    = 8200;
+    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
+        0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
+        0x78, 0x00, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    hventerstabdelay    = 100;
+    hvspcmdexedelay     = 5;
+    synchcycles         = 6;
+    latchcycles         = 16;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 0;
+    resetdelayus        = 50;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    memory "eeprom"
+        size            = 64;
+        min_write_delay = 8200;
+        max_write_delay = 8200;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
+                          "x  x a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+
+        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
+                          "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+
+	mode		= 0x04;
+	delay		= 10;
+	blocksize	= 64;
+	readsize	= 256;
+    ;
+
+    memory "flash"
+        size            = 1024;
+        min_write_delay = 4100;
+        max_write_delay = 4100;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0  0  1  0   0  0  0  0",
+                          "  x  x  x  x   x  x  x a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  o  o  o  o   o  o  o  o";
+
+        read_hi         = "  0  0  1  0   1  0  0  0",
+                          "  x  x  x  x   x  x  x a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  o  o  o  o   o  o  o  o";
+
+        write_lo        = "  0  1  0  0   0  0  0  0",
+                          "  x  x  x  x   x  x  x a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        write_hi        = "  0  1  0  0   1  0  0  0",
+                          "  x  x  x  x   x  x  x a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+	mode		= 0x04;
+	delay		= 5;
+	blocksize	= 128;
+	readsize	= 256;
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+    ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
+                          "x  x  x  x   x  x  x  x    x x x x  x o o x";
+
+        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 i i 1",
+                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+    ;
+
+    memory "fuse"
+        size            = 1;
+        read            = "0  1  0  1   0  0  0  0    x x x x  x x x x",
+                          "x  x  x  x   x  x  x  x    o o o o  x x o o";
+
+        write           = "1  0  1  0   1  1  0  0    1 0 1 x  x x x x",
+                          "x  x  x  x   x  x  x  x    i i i i  1 1 i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+;
+
+#------------------------------------------------------------
+# AT90s1200
+#------------------------------------------------------------
+
+part
+    id               = "1200";
+    desc             = "AT90S1200";
+    is_at90s1200     = yes;
+    stk500_devcode   = 0x33;
+    avr910_devcode   = 0x13;
+    signature        = 0x1e 0x90 0x01;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+    chip_erase_delay = 20000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 1;
+    bytedelay		= 0;
+    pollindex		= 0;
+    pollvalue		= 0xFF;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 0;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 15;
+    chiperasepolltimeout = 0;
+    programfusepulsewidth = 2;
+    programfusepolltimeout = 0;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 1;
+
+    memory "eeprom"
+        size            = 64;
+        min_write_delay = 4000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0xff;
+        read            = "1 0  1  0   0  0  0  0   x x x x  x x x x", 
+                          "x x a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = "1 1  0  0   0  0  0  0   x x x x  x x x x",
+                          "x x a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	mode		= 0x04;
+	delay		= 20;
+	blocksize	= 32;
+	readsize	= 256;
+      ;
+    memory "flash"
+        size            = 1024;
+        min_write_delay = 4000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  x   x   x   x    x   x   x  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  x   x   x   x    x   x   x  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        write_lo        = "  0   1   0   0    0   0   0   0",
+                          "  x   x   x   x    x   x   x  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+        write_hi        = "  0   1   0   0    1   0   0   0",
+                          "  x   x   x   x    x   x   x  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+	mode		= 0x02;
+	delay		= 15;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+    memory "fuse"
+        size            = 1;
+      ;
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90s4414
+#------------------------------------------------------------
+
+part
+    id               = "4414";
+    desc             = "AT90S4414";
+    stk500_devcode   = 0x50;
+    avr910_devcode   = 0x28;
+    signature        = 0x1e 0x92 0x01;
+    chip_erase_delay = 20000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 0;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 15;
+    chiperasepolltimeout = 0;
+    programfusepulsewidth = 2;
+    programfusepolltimeout = 0;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 1;
+
+    memory "eeprom"
+        size            = 256;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0x80;
+        readback_p2     = 0x7f;
+        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8", 
+                          "a7 a6 a5 a4 a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
+                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+    memory "flash"
+        size            = 4096;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0x7f;
+        readback_p2     = 0x7f;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        write_lo        = "  0   1   0   0    0   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+        write_hi        = "  0   1   0   0    1   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+    memory "fuse"
+	size		= 1;
+      ;
+    memory "lock"
+	size		= 1;
+	write		= "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
+			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90s2313
+#------------------------------------------------------------
+
+part
+    id               = "2313";
+    desc             = "AT90S2313";
+    stk500_devcode   = 0x40;
+    avr910_devcode   = 0x20;
+    signature        = 0x1e 0x91 0x01;
+    chip_erase_delay = 20000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 0;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 15;
+    chiperasepolltimeout = 0;
+    programfusepulsewidth = 2;
+    programfusepolltimeout = 0;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 1;
+
+    memory "eeprom"
+        size            = 128;
+        min_write_delay = 4000;
+        max_write_delay = 9000;
+        readback_p1     = 0x80;
+        readback_p2     = 0x7f;
+        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x", 
+                          "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = "1  1  0  0   0  0  0  0   x x x x  x x x x",
+                          "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+    memory "flash"
+        size            = 2048;
+        min_write_delay = 4000;
+        max_write_delay = 9000;
+        readback_p1     = 0x7f;
+        readback_p2     = 0x7f;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        write_lo        = "  0   1   0   0    0   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+        write_hi        = "  0   1   0   0    1   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+    memory "fuse"
+        size            = 1;
+      ;
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x i i x",
+                          "x x x x  x x x x  x x x x  x x x x";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90s2333
+#------------------------------------------------------------
+
+part
+    id               = "2333";
+##### WARNING: No XML file for device 'AT90S2333'! #####
+    desc             = "AT90S2333";
+    stk500_devcode   = 0x42;
+    avr910_devcode   = 0x34;
+    signature        = 0x1e 0x91 0x05;
+    chip_erase_delay = 20000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 0;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 15;
+    chiperasepolltimeout = 0;
+    programfusepulsewidth = 2;
+    programfusepolltimeout = 0;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 1;
+
+    memory "eeprom"
+        size            = 128;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0x00;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x", 
+                          "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = "1  1  0  0   0  0  0  0   x x x x  x x x x",
+                          "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        size            = 2048;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        write_lo        = "  0   1   0   0    0   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+        write_hi        = "  0   1   0   0    1   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+    memory "fuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        pwroff_after_write = yes;
+        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
+                          "x x x x  x x x x   x x x x  x x x x";
+      ;
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
+                          "x x x x  x x x x   x x x x  x o o x";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+      ;
+  ;
+
+
+#------------------------------------------------------------
+# AT90s2343 (also AT90s2323 and ATtiny22)
+#------------------------------------------------------------
+
+part
+    id               = "2343";
+    desc             = "AT90S2343";
+    stk500_devcode   = 0x43;
+    avr910_devcode   = 0x4c;
+    signature        = 0x1e 0x91 0x03;
+    chip_erase_delay = 18000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
+        0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
+        0x78, 0x00, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    hventerstabdelay    = 100;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 0;
+    poweroffdelay       = 25;
+    resetdelayms        = 0;
+    resetdelayus        = 50;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    memory "eeprom"
+        size            = 128;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0x00;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0   0 0 0 0  0 0 0 0", 
+                          "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = "1  1  0  0   0  0  0  0   0 0 0 0  0 0 0 0",
+                          "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+    memory "flash"
+        size            = 2048;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        write_lo        = "  0   1   0   0    0   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+        write_hi        = "  0   1   0   0    1   0   0   0",
+                          "  x   x   x   x    x   x  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 128;
+	readsize	= 128;
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+    memory "fuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
+                          "x x x x  x x x x   o o o x  x x x o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 1  1 1 1 i",
+                          "x x x x  x x x x   x x x x  x x x x";
+      ;
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
+                          "x x x x  x x x x   o o o x  x x x o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+      ;
+  ;
+
+
+#------------------------------------------------------------
+# AT90s4433
+#------------------------------------------------------------
+
+part
+    id               = "4433";
+    desc             = "AT90S4433";
+    stk500_devcode   = 0x51;
+    avr910_devcode   = 0x30;
+    signature        = 0x1e 0x92 0x03;
+    chip_erase_delay = 20000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 0;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 15;
+    chiperasepolltimeout = 0;
+    programfusepulsewidth = 2;
+    programfusepolltimeout = 0;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 1;
+
+    memory "eeprom"
+        size            = 256;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0x00;
+        readback_p2     = 0xff;
+        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x", 
+                          "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x x",
+                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+    memory "flash"
+        size            = 4096;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  x   x   x   x    x a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  x   x   x   x    x a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        write_lo        = "  0   1   0   0    0   0   0   0",
+                          "  x   x   x   x    x a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+        write_hi        = "  0   1   0   0    1   0   0   0",
+                          "  x   x   x   x    x a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+    memory "fuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        pwroff_after_write = yes;
+        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
+                          "x x x x  x x x x   x x x x  x x x x";
+      ;
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
+                          "x x x x  x x x x   x x x x  x o o x";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90s4434
+#------------------------------------------------------------
+
+part
+    id               = "4434";
+##### WARNING: No XML file for device 'AT90S4434'! #####
+    desc             = "AT90S4434";
+    stk500_devcode   = 0x52;
+    avr910_devcode   = 0x6c;
+    signature        = 0x1e 0x92 0x02;
+    chip_erase_delay = 20000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    memory "eeprom"
+        size            = 256;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0x00;
+        readback_p2     = 0xff;
+        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x", 
+                          "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x x",
+                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+      ;
+    memory "flash"
+        size            = 4096;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  x   x   x   x    x a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  x   x   x   x    x a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        write_lo        = "  0   1   0   0    0   0   0   0",
+                          "  x   x   x   x    x a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+        write_hi        = "  0   1   0   0    1   0   0   0",
+                          "  x   x   x   x    x a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+    memory "fuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
+                          "x x x x  x x x x   x x x x  x x x x";
+      ;
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
+                          "x x x x  x x x x   x x x x  x o o x";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90s8515
+#------------------------------------------------------------
+
+part
+    id               = "8515";
+    desc             = "AT90S8515";
+    stk500_devcode   = 0x60;
+    avr910_devcode   = 0x38;
+    signature        = 0x1e 0x93 0x01;
+    chip_erase_delay = 20000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 0;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepulsewidth = 15;
+    chiperasepolltimeout = 0;
+    programfusepulsewidth = 2;
+    programfusepolltimeout = 0;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 1;
+
+    memory "eeprom"
+        size            = 512;
+        min_write_delay = 4000;
+        max_write_delay = 9000;
+        readback_p1     = 0x80;
+        readback_p2     = 0x7f;
+        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8", 
+                          "a7 a6 a5 a4 a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
+                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+    memory "flash"
+        size            = 8192;
+        min_write_delay = 4000;
+        max_write_delay = 9000;
+        readback_p1     = 0x7f;
+        readback_p2     = 0x7f;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        write_lo        = "  0   1   0   0    0   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+        write_hi        = "  0   1   0   0    1   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+    memory "fuse"
+	size		= 1;
+      ;
+    memory "lock"
+	size		= 1;
+	write		= "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
+			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90s8535
+#------------------------------------------------------------
+
+part
+    id               = "8535";
+    desc             = "AT90S8535";
+    stk500_devcode   = 0x61;
+    avr910_devcode   = 0x68;
+    signature        = 0x1e 0x93 0x03;
+    chip_erase_delay = 20000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 0;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 15;
+    chiperasepolltimeout = 0;
+    programfusepulsewidth = 2;
+    programfusepolltimeout = 0;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 1;
+
+    memory "eeprom"
+        size            = 512;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0x00;
+        readback_p2     = 0xff;
+        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x a8", 
+                          "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
+                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+    memory "flash"
+        size            = 8192;
+        min_write_delay = 9000;
+        max_write_delay = 20000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        write_lo        = "  0   1   0   0    0   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+        write_hi        = "  0   1   0   0    1   0   0   0",
+                          "  x   x   x   x  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+    memory "fuse"
+	size		= 1;
+	read		= "0  1  0  1   1  0  0  0   x  x  x  x   x  x  x  x",
+			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  o";
+	write		= "1  0  1  0   1  1  0  0   1  0  1  1   1  1  1  i",
+			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+    memory "lock"
+	size		= 1;
+	read		= "0  1  0  1   1  0  0  0   x  x  x  x   x  x  x  x",
+			  "x  x  x  x   x  x  x  x   o  o  x  x   x  x  x  x";
+	write		= "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
+			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega103
+#------------------------------------------------------------
+
+part
+    id               = "m103";
+    desc             = "ATmega103";
+    stk500_devcode   = 0xB1;
+    avr910_devcode   = 0x41;
+    signature        = 0x1e 0x97 0x01;
+    chip_erase_delay = 112000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x8E, 0x9E, 0x2E, 0x3E, 0xAE, 0xBE,
+        0x4E, 0x5E, 0xCE, 0xDE, 0x6E, 0x7E, 0xEE, 0xDE,
+        0x66, 0x76, 0xE6, 0xF6, 0x6A, 0x7A, 0xEA, 0x7A,
+        0x7F, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 0;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 15;
+    chiperasepolltimeout = 0;
+    programfusepulsewidth = 2;
+    programfusepolltimeout = 0;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 10;
+
+    memory "eeprom"
+        size            = 4096;
+        min_write_delay = 4000;
+        max_write_delay = 9000;
+        readback_p1     = 0x80;
+        readback_p2     = 0x7f;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 131072;
+        page_size       = 256;
+        num_pages       = 512;
+        min_write_delay = 22000;
+        max_write_delay = 56000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x11;
+	delay		= 70;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "fuse"
+        size            = 1;
+        read            = "0 1 0 1  0 0 0 0  x x x x  x x x x",
+                          "x x x x  x x x x  x x o x  o 1 o o";
+
+        write           = "1 0 1 0  1 1 0 0  1 0 1 1  i 1 i i",
+                          "x x x x  x x x x  x x x x  x x x x";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
+                          "x x x x  x x x x   x x x x  x o o x";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+
+#------------------------------------------------------------
+# ATmega64
+#------------------------------------------------------------
+
+part
+    id               = "m64";
+    desc             = "ATmega64";
+    has_jtag         = yes;
+    stk500_devcode   = 0xA0;
+    avr910_devcode   = 0x45;
+    signature        = 0x1e 0x96 0x02;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x22;
+    spmcr               = 0x68;
+    allowfullpagebitstream = yes;
+
+    ocdrev              = 2;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 2048;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 20;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 65536;
+        page_size       = 256;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  x a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  x a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  x a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  x x i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 4;
+        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
+                          "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+
+
+
+#------------------------------------------------------------
+# ATmega128
+#------------------------------------------------------------
+
+part
+    id               = "m128";
+    desc             = "ATmega128";
+    has_jtag         = yes;
+    stk500_devcode   = 0xB2;
+    avr910_devcode   = 0x43;
+    signature        = 0x1e 0x97 0x02;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x22;
+    spmcr               = 0x68;
+    rampz               = 0x3b;
+    allowfullpagebitstream = yes;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 4096;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 12;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 131072;
+        page_size       = 256;
+        num_pages       = 512;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  x x i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 4;
+        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
+                          "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90CAN128
+#------------------------------------------------------------
+
+part
+    id               = "c128";
+    desc             = "AT90CAN128";
+    has_jtag         = yes;
+    stk500_devcode   = 0xB3;
+#    avr910_devcode   = 0x43;
+    signature        = 0x1e 0x97 0x81;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    rampz               = 0x3b;
+    eecr                = 0x3f;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 4096;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x    a11 a10  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 8;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 131072;
+        page_size       = 256;
+        num_pages       = 512;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90CAN64
+#------------------------------------------------------------
+
+part
+    id               = "c64";
+    desc             = "AT90CAN64";
+    has_jtag         = yes;
+    stk500_devcode   = 0xB3;
+#    avr910_devcode   = 0x43;
+    signature        = 0x1e 0x96 0x81;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    rampz               = 0x3b;
+    eecr                = 0x3f;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 2048;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x a10  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 8;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 65536;
+        page_size       = 256;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90CAN32
+#------------------------------------------------------------
+
+part
+    id               = "c32";
+    desc             = "AT90CAN32";
+    has_jtag         = yes;
+    stk500_devcode   = 0xB3;
+#    avr910_devcode   = 0x43;
+    signature        = 0x1e 0x95 0x81;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    rampz               = 0x3b;
+    eecr                = 0x3f;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 1024;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 8;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 32768;
+        page_size       = 256;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+
+#------------------------------------------------------------
+# ATmega16
+#------------------------------------------------------------
+
+part
+    id               = "m16";
+    desc             = "ATmega16";
+    has_jtag         = yes;
+    stk500_devcode   = 0x82;
+    avr910_devcode   = 0x74;
+    signature        = 0x1e 0x94 0x03;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 100;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    allowfullpagebitstream = yes;
+
+    ocdrev              = 2;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 512;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x  a9  a8",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x04;
+	delay		= 10;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+    memory "calibration"
+        size            = 4;
+
+        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 a1 a0 o o o o  o o o o";
+        ;
+  ;
+
+
+#------------------------------------------------------------
+# ATmega164P
+#------------------------------------------------------------
+
+# close to ATmega16
+
+part parent "m16"
+    id               = "m164p";
+    desc             = "ATmega164P";
+    signature        = 0x1e 0x94 0x0a;
+
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    allowfullpagebitstream = no;
+    chip_erase_delay = 55000;
+
+    ocdrev              = 3;
+  ;
+
+
+#------------------------------------------------------------
+# ATmega324P
+#------------------------------------------------------------
+
+# similar to ATmega164P
+
+part
+    id               = "m324p";
+    desc             = "ATmega324P";
+    has_jtag         = yes;
+    stk500_devcode   = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode   = 0x74;
+    signature        = 0x1e 0x95 0x08;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+    chip_erase_delay = 55000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 1024;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x a10  a9  a8",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 32768;
+        page_size       = 128;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 6;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  1 1 1 1  1 i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "calibration"
+        size            = 1;
+
+        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        ;
+  ;
+
+
+#------------------------------------------------------------
+# ATmega324PA
+#------------------------------------------------------------
+
+# similar to ATmega324P
+
+part parent "m324p"
+    id               = "m324pa";
+    desc             = "ATmega324PA";
+    signature        = 0x1e 0x95 0x11;
+
+    ocdrev              = 3;
+  ;
+
+
+#------------------------------------------------------------
+# ATmega644
+#------------------------------------------------------------
+
+# similar to ATmega164
+
+part
+    id               = "m644";
+    desc             = "ATmega644";
+    has_jtag         = yes;
+    stk500_devcode   = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode   = 0x74;
+    signature        = 0x1e 0x96 0x09;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+    chip_erase_delay = 55000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 2048;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x    a11 a10  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 65536;
+        page_size       = 256;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 6;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  1 1 1 1  1 i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "calibration"
+        size            = 1;
+
+        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        ;
+  ;
+
+#------------------------------------------------------------
+# ATmega644P
+#------------------------------------------------------------
+
+# similar to ATmega164p
+
+part parent "m644"
+    id               = "m644p";
+    desc             = "ATmega644P";
+    signature        = 0x1e 0x96 0x0a;
+
+    ocdrev              = 3;
+  ;
+
+
+
+#------------------------------------------------------------
+# ATmega1284P
+#------------------------------------------------------------
+
+# similar to ATmega164p
+
+part
+    id               = "m1284p";
+    desc             = "ATmega1284P";
+    has_jtag         = yes;
+    stk500_devcode   = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode   = 0x74;
+    signature        = 0x1e 0x97 0x05;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+    chip_erase_delay = 55000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 4096;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x    a11 a10  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 131072;
+        page_size       = 256;
+        num_pages       = 512;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  1 1 1 1  1 i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "calibration"
+        size            = 1;
+
+        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        ;
+  ;
+
+
+
+#------------------------------------------------------------
+# ATmega162
+#------------------------------------------------------------
+
+part
+    id               = "m162";
+    desc             = "ATmega162";
+    has_jtag         = yes;
+    stk500_devcode   = 0x83;
+    avr910_devcode   = 0x63;
+    signature        = 0x1e 0x94 0x04;
+    chip_erase_delay = 9000;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+
+    idr              = 0x04;
+    spmcr            = 0x57;
+    allowfullpagebitstream = yes;
+
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    ocdrev              = 2;
+
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+       mode        = 0x41;
+    delay       = 10;
+    blocksize   = 128;
+    readsize    = 256;  
+
+        ;
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 512;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+
+                read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+                write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x  a9  a8",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+        ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 16000;
+        max_write_delay = 16000;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+        ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 16000;
+        max_write_delay = 16000;
+
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+        ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 16000;
+        max_write_delay = 16000;
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  1 1 1 1  1 i i i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 16000;
+        max_write_delay = 16000;
+
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        ;
+
+    memory "signature"
+        size            = 3;
+
+        read            = "0  0  1  1   0  0  0  0   0  0  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        ;
+
+    memory "calibration"
+        size            = 1;
+
+        read            = "0 0 1 1  1 0 0 0   0 0 x x  x x x x",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        ;
+;
+
+
+
+#------------------------------------------------------------
+# ATmega163
+#------------------------------------------------------------
+
+part
+    id               = "m163";
+    desc             = "ATmega163";
+    stk500_devcode   = 0x81;
+    avr910_devcode   = 0x64;
+    signature        = 0x1e 0x94 0x02;
+    chip_erase_delay = 32000;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 0;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 30;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 2;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 2;
+
+
+   memory "eeprom"
+        size            = 512;
+        min_write_delay = 4000;
+        max_write_delay = 4000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 16000;
+        max_write_delay = 16000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  x   x   x a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  x   x   x a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  x   x   x a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x11;
+	delay		= 20;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o x x  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i 1 1  i i i i";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   x x x x  1 o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   1 1 1 1  1 i i i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  0 x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0   x x x x  x x x x",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega169
+#------------------------------------------------------------
+
+part
+    id               = "m169";
+    desc             = "ATmega169";
+    has_jtag         = yes;
+    stk500_devcode   = 0x85;
+    avr910_devcode   = 0x78;
+    signature        = 0x1e 0x94 0x05;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+
+    ocdrev              = 2;
+
+   memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 512;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x  a8",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  x   x   x a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  x   x   x a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  x   x   x a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega329
+#------------------------------------------------------------
+
+part
+    id               = "m329";
+    desc             = "ATmega329";
+    has_jtag         = yes;
+#    stk500_devcode   = 0x85; # no STK500 support, only STK500v2
+#    avr910_devcode   = 0x?;  # try the ATmega169 one:
+    avr910_devcode   = 0x75;
+    signature        = 0x1e 0x95 0x03;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+
+    ocdrev              = 3;
+
+   memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 1024;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x  a9  a8",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 8;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 32768;
+        page_size       = 128;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  x a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  x a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  x   x   x a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x   x x x x  x i i i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega329P
+#------------------------------------------------------------
+# Identical to ATmega329 except of the signature
+
+part parent "m329"
+    id               = "m329p";
+    desc             = "ATmega329P";
+    signature        = 0x1e 0x95 0x0b;
+
+    ocdrev              = 3;
+  ;
+
+#------------------------------------------------------------
+# ATmega3290
+#------------------------------------------------------------
+
+# identical to ATmega329
+
+part parent "m329"
+    id               = "m3290";
+    desc             = "ATmega3290";
+    signature        = 0x1e 0x95 0x04;
+
+    ocdrev              = 3;
+  ;
+
+#------------------------------------------------------------
+# ATmega3290P
+#------------------------------------------------------------
+
+# identical to ATmega3290 except of the signature
+
+part parent "m3290"
+    id               = "m3290p";
+    desc             = "ATmega3290P";
+    signature        = 0x1e 0x95 0x0c;
+
+    ocdrev              = 3;
+  ;
+
+#------------------------------------------------------------
+# ATmega649
+#------------------------------------------------------------
+
+part
+    id               = "m649";
+    desc             = "ATmega649";
+    has_jtag         = yes;
+#    stk500_devcode   = 0x85; # no STK500 support, only STK500v2
+#    avr910_devcode   = 0x?;  # try the ATmega169 one:
+    avr910_devcode   = 0x75;
+    signature        = 0x1e 0x96 0x03;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+
+    ocdrev              = 3;
+
+   memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 2048;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x a10  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 8;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 65536;
+        page_size       = 256;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  x   x   x a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x   x x x x  x i i i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega6490
+#------------------------------------------------------------
+
+# identical to ATmega649
+
+part parent "m649"
+    id               = "m6490";
+    desc             = "ATmega6490";
+    signature        = 0x1e 0x96 0x04;
+
+    ocdrev              = 3;
+  ;
+
+#------------------------------------------------------------
+# ATmega32
+#------------------------------------------------------------
+
+part
+    id               = "m32";
+    desc             = "ATmega32";
+    has_jtag         = yes;
+    stk500_devcode   = 0x91;
+    avr910_devcode   = 0x72;
+    signature        = 0x1e 0x95 0x02;
+    chip_erase_delay = 9000;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    allowfullpagebitstream = yes;
+
+    ocdrev              = 2;
+
+   memory "eeprom"
+        paged           = no;   /* leave this "no" */
+        page_size       = 4;    /* for parallel programming */
+        size            = 1024;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x  a9  a8",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x04;
+	delay		= 10;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 32768;
+        page_size       = 128;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 6;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o o";
+      ;
+
+    memory "calibration"
+        size            = 4;
+        read            = "0 0 1 1  1 0 0 0    0 0 x x  x x x x",
+                          "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega161
+#------------------------------------------------------------
+
+part
+    id               = "m161";
+    desc             = "ATmega161";
+    stk500_devcode   = 0x80;
+    avr910_devcode   = 0x60;
+    signature        = 0x1e 0x94 0x01;
+    chip_erase_delay = 28000;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 0;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 30;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 2;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 2;
+
+   memory "eeprom"
+        size            = 512;
+        min_write_delay = 3400;
+        max_write_delay = 3400;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 5;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 14000;
+        max_write_delay = 14000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  x   x   x a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  x   x   x a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  x   x   x a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 16;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "fuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
+                          "x x x x  x x x x   x o x o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 x  x x x x",
+                          "x x x x  x x x x   1 i 1 i  i i i i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+
+#------------------------------------------------------------
+# ATmega8
+#------------------------------------------------------------
+
+part
+    id               = "m8";
+    desc             = "ATmega8";
+    stk500_devcode   = 0x70;
+    avr910_devcode   = 0x76;
+    signature        = 0x1e 0x93 0x07;
+    pagel            = 0xd7;
+    bs2              = 0xc2;
+    chip_erase_delay = 10000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 2;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    memory "eeprom"
+        size            = 512;
+        page_size       = 4;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 20;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  0   0   0   0  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  0   0   0   0  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   0   0      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   0   0      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 10;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+
+    memory "calibration"
+        size            = 4;
+        read            = "0  0  1  1   1  0  0  0   0  0  x  x   x  x  x  x",
+                          "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+
+
+#------------------------------------------------------------
+# ATmega8515
+#------------------------------------------------------------
+
+part
+    id               = "m8515";
+    desc             = "ATmega8515";
+    stk500_devcode   = 0x63;
+    avr910_devcode   = 0x3A;
+    signature        = 0x1e 0x93 0x06;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    memory "eeprom"
+        size            = 512;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+ read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+ write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 20;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  0   0   0   0  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  0   0   0   0  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   0   0      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   0   0      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 6;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+
+    memory "calibration"
+        size            = 4;
+        read            = "0 0 1 1  1 0 0 0     0 0 x x  x x x x",
+                          "0 0 0 0  0 0 a1 a0   o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+
+
+
+#------------------------------------------------------------
+# ATmega8535
+#------------------------------------------------------------
+
+part
+    id               = "m8535";
+    desc             = "ATmega8535";
+    stk500_devcode   = 0x64;
+    avr910_devcode   = 0x69;
+    signature        = 0x1e 0x93 0x08;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    memory "eeprom"
+        size            = 512;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	mode		= 0x04;
+	delay		= 20;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  0   0   0   0  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  0   0   0   0  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   0   0      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   0   0      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 6;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+
+    memory "calibration"
+        size            = 4;
+        read            = "0 0 1 1  1 0 0 0   0 0 x x  x x x x",
+                          "0 0 0 0  0 0 a1 a0 o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+
+#------------------------------------------------------------
+# ATtiny26
+#------------------------------------------------------------
+
+part
+    id                  = "t26";
+    desc                = "ATtiny26";
+    stk500_devcode      = 0x21;
+    avr910_devcode      = 0x5e;
+    signature           = 0x1e 0x91 0x09;
+    pagel               = 0xb3;
+    bs2                 = 0xb2;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
+        0xD4, 0xF4, 0xD4, 0xF4, 0xDC, 0xFC, 0xDC, 0xFC,
+        0xC8, 0xE8, 0xD8, 0xF8, 0x4C, 0x6C, 0x5C, 0x7C,
+        0xEC, 0xBC, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 2;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    memory "eeprom"
+        size            = 128;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
+                          "x a6 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+
+        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
+                          "x a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+
+	mode		= 0x04;
+	delay		= 10;
+	blocksize	= 64;
+	readsize	= 256;
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 2048;
+        page_size       = 32;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0  0  1  0   0  0  0  0",
+                          "  x  x  x  x   x  x a9 a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  o  o  o  o   o  o  o  o";
+
+        read_hi         = "  0  0  1  0   1  0  0  0",
+                          "  x  x  x  x   x  x a9 a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  o  o  o  o   o  o  o  o";
+
+        loadpage_lo     = "  0  1  0  0   0  0  0  0",
+                          "  x  x  x  x   x  x  x  x",
+                          "  x  x  x  x  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        loadpage_hi     = "  0  1  0  0   1  0  0  0",
+                          "  x  x  x  x   x  x  x  x",
+                          "  x  x  x  x  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        writepage       = "  0  1  0  0   1  1  0  0",
+                          "  x  x  x  x   x  x a9 a8",
+                          " a7 a6 a5 a4   x  x  x  x",
+                          "  x  x  x  x   x  x  x  x";
+
+	mode		= 0x21;
+	delay		= 6;
+	blocksize	= 16;
+	readsize	= 256;
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+    ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
+                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
+
+        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
+                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  x x x i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  x x x o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 4;
+        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+    ;
+
+;
+
+
+#------------------------------------------------------------
+# ATtiny261
+#------------------------------------------------------------
+# Close to ATtiny26
+
+part
+    id                  = "t261";
+    desc                = "ATtiny261";
+     has_debugwire = yes;
+     flash_instr   = 0xB4, 0x00, 0x10;
+     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+	             0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
+	             0x99, 0xE1, 0xBB, 0xAC;
+#    stk500_devcode      = 0x21;
+#    avr910_devcode      = 0x5e;
+    signature           = 0x1e 0x91 0x0c;
+    pagel               = 0xb3;
+    bs2                 = 0xb2;
+    chip_erase_delay    = 4000;
+
+    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
+        0xD4, 0xF4, 0xD4, 0xF4, 0xDC, 0xFC, 0xDC, 0xFC,
+        0xC8, 0xE8, 0xD8, 0xF8, 0x4C, 0x6C, 0x5C, 0x7C,
+        0xEC, 0xBC, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 2;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no;
+        size            = 128;
+        page_size       = 4;
+        num_pages       = 32;
+        min_write_delay = 4000;
+        max_write_delay = 4000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+
+        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
+                          "x a6 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+
+        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
+                          "x a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  "  x  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 4;
+	readsize	= 256;
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 2048;
+        page_size       = 32;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+
+        read_lo         = "  0  0  1  0   0  0  0  0",
+                          "  x  x  x  x   x  x a9 a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  o  o  o  o   o  o  o  o";
+
+        read_hi         = "  0  0  1  0   1  0  0  0",
+                          "  x  x  x  x   x  x a9 a8",
+                          " a7 a6 a5 a4  a3 a2 a1 a0",
+                          "  o  o  o  o   o  o  o  o";
+
+        loadpage_lo     = "  0  1  0  0   0  0  0  0",
+                          "  x  x  x  x   x  x  x  x",
+                          "  x  x  x  x  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        loadpage_hi     = "  0  1  0  0   1  0  0  0",
+                          "  x  x  x  x   x  x  x  x",
+                          "  x  x  x  x  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        writepage       = "  0  1  0  0   1  1  0  0",
+                          "  x  x  x  x   x  x a9 a8",
+                          " a7 a6 a5 a4   x  x  x  x",
+                          "  x  x  x  x   x  x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 32;
+	readsize	= 256;
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+    ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
+                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
+
+        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
+                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x   x x x x  x x x i";
+
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   x x x x  x x x o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+    ;
+
+;
+
+
+#------------------------------------------------------------
+# ATtiny461
+#------------------------------------------------------------
+# Close to ATtiny261
+
+part
+    id                  = "t461";
+    desc                = "ATtiny461";
+     has_debugwire = yes;
+     flash_instr   = 0xB4, 0x00, 0x10;
+     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+	             0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
+	             0x99, 0xE1, 0xBB, 0xAC;
+#    stk500_devcode      = 0x21;
+#    avr910_devcode      = 0x5e;
+    signature           = 0x1e 0x92 0x08;
+    pagel               = 0xb3;
+    bs2                 = 0xb2;
+    chip_erase_delay    = 4000;
+
+    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
+        0xD4, 0xF4, 0xD4, 0xF4, 0xDC, 0xFC, 0xDC, 0xFC,
+        0xC8, 0xE8, 0xD8, 0xF8, 0x4C, 0x6C, 0x5C, 0x7C,
+        0xEC, 0xBC, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 2;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no;
+        size            = 256;
+        page_size       = 4;
+        num_pages       = 64;
+        min_write_delay = 4000;
+        max_write_delay = 4000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+
+        read            = " 1  0  1  0   0  0  0  0    x x x x  x x x x",
+                          "a7 a6 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+
+        write           = " 1  1  0  0   0  0  0  0    x x x x  x x x x",
+                          "a7 a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 4;
+	readsize	= 256;
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 4096;
+        page_size       = 64;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+
+        read_lo         = "  0  0  1  0   0   0  0  0",
+                          "  x  x  x  x   x a10 a9 a8",
+                          " a7 a6 a5 a4  a3  a2 a1 a0",
+                          "  o  o  o  o   o   o  o  o";
+
+        read_hi         = "  0  0  1  0   1   0  0  0",
+                          "  x  x  x  x   x a10 a9 a8",
+                          " a7 a6 a5 a4  a3  a2 a1 a0",
+                          "  o  o  o  o   o   o  o  o";
+
+        loadpage_lo     = "  0  1  0  0   0  0  0  0",
+                          "  x  x  x  x   x  x  x  x",
+                          "  x  x  x a4  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        loadpage_hi     = "  0  1  0  0   1  0  0  0",
+                          "  x  x  x  x   x  x  x  x",
+                          "  x  x  x a4  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        writepage       = "  0  1  0  0   1   1  0  0",
+                          "  x  x  x  x   x a10 a9 a8",
+                          " a7 a6 a5  x   x   x  x  x",
+                          "  x  x  x  x   x   x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 64;
+	readsize	= 256;
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+    ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
+                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
+
+        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
+                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x   x x x x  x x x i";
+
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   x x x x  x x x o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+    ;
+
+;
+
+
+#------------------------------------------------------------
+# ATtiny861
+#------------------------------------------------------------
+# Close to ATtiny461
+
+part
+    id                  = "t861";
+    desc                = "ATtiny861";
+     has_debugwire = yes;
+     flash_instr   = 0xB4, 0x00, 0x10;
+     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+	             0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
+	             0x99, 0xE1, 0xBB, 0xAC;
+#    stk500_devcode      = 0x21;
+#    avr910_devcode      = 0x5e;
+    signature           = 0x1e 0x93 0x0d;
+    pagel               = 0xb3;
+    bs2                 = 0xb2;
+    chip_erase_delay    = 4000;
+
+    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
+                          "x x x x  x x x x   x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 0;
+
+    pp_controlstack     =
+        0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
+        0xD4, 0xF4, 0xD4, 0xF4, 0xDC, 0xFC, 0xDC, 0xFC,
+        0xC8, 0xE8, 0xD8, 0xF8, 0x4C, 0x6C, 0x5C, 0x7C,
+        0xEC, 0xBC, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 2;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no;
+        size            = 512;
+        num_pages       = 128;
+        page_size       = 4;
+        min_write_delay = 4000;
+        max_write_delay = 4000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+
+        read            = " 1  0  1  0   0  0  0  0    x x x x  x x x a8",
+                          "a7 a6 a5 a4  a3 a2 a1 a0    o o o o  o o o  o";
+
+        write           = " 1  1  0  0   0  0  0  0    x x x x  x x x a8",
+                          "a7 a6 a5 a4  a3 a2 a1 a0    i i i i  i i i  i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x  a8",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 4;
+	readsize	= 256;
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+
+        read_lo         = "  0  0  1  0   0   0  0  0",
+                          "  x  x  x  x a11 a10 a9 a8",
+                          " a7 a6 a5 a4  a3  a2 a1 a0",
+                          "  o  o  o  o   o   o  o  o";
+
+        read_hi         = "  0  0  1  0   1   0  0  0",
+                          "  x  x  x  x a11 a10 a9 a8",
+                          " a7 a6 a5 a4  a3  a2 a1 a0",
+                          "  o  o  o  o   o   o  o  o";
+
+        loadpage_lo     = "  0  1  0  0   0  0  0  0",
+                          "  x  x  x  x   x  x  x  x",
+                          "  x  x  x a4  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        loadpage_hi     = "  0  1  0  0   1  0  0  0",
+                          "  x  x  x  x   x  x  x  x",
+                          "  x  x  x a4  a3 a2 a1 a0",
+                          "  i  i  i  i   i  i  i  i";
+
+        writepage       = "  0  1  0  0   1   1  0  0",
+                          "  x  x  x  x a11 a10 a9 a8",
+                          " a7 a6 a5  x   x   x  x  x",
+                          "  x  x  x  x   x   x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 64;
+	readsize	= 256;
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+    ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
+                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
+
+        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
+                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x   x x x x  x x x i";
+
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   x x x x  x x x o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
+                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+    ;
+
+;
+
+
+#------------------------------------------------------------
+# ATmega48
+#------------------------------------------------------------
+
+part
+    id               = "m48";
+    desc             = "ATmega48";
+     has_debugwire = yes;
+     flash_instr   = 0xB6, 0x01, 0x11;
+     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
+	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+	             0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode   = 0x59;
+#    avr910_devcode   = 0x;
+    signature        = 0x1e 0x92 0x05;
+    pagel            = 0xd7;
+    bs2              = 0xc2;
+    chip_erase_delay = 45000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no;
+        page_size       = 4;
+        size            = 256;
+        min_write_delay = 3600;
+        max_write_delay = 3600;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+      ;
+    memory "flash"
+        paged           = yes;
+        size            = 4096;
+        page_size       = 64;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  0   0   0   0    0 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  0   0   0   0    0 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0   0   0   0      0 a10  a9  a8",
+                          " a7  a6  a5   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   x x x x  x x x o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x   x x x x  x x x i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
+                          "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega48P
+#------------------------------------------------------------
+
+part parent "m48"
+    id               = "m48p";
+    desc             = "ATmega48P";
+    signature        = 0x1e 0x92 0x0a;
+
+    ocdrev              = 1;
+  ;
+
+#------------------------------------------------------------
+# ATmega88
+#------------------------------------------------------------
+
+part
+    id               = "m88";
+    desc             = "ATmega88";
+     has_debugwire = yes;
+     flash_instr   = 0xB6, 0x01, 0x11;
+     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
+	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+	             0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode   = 0x73;
+#    avr910_devcode   = 0x;
+    signature        = 0x1e 0x93 0x0a;
+    pagel            = 0xd7;
+    bs2              = 0xc2;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no;
+        page_size       = 4;
+        size            = 512;
+        min_write_delay = 3600;
+        max_write_delay = 3600;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x  a8",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+      ;
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  0   0   0   0  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  0   0   0   0  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   x x x x  x o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x   x x x x  x i i i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
+                          "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega88P
+#------------------------------------------------------------
+
+part parent "m88"
+    id               = "m88p";
+    desc             = "ATmega88P";
+    signature        = 0x1e 0x93 0x0f;
+
+    ocdrev              = 1;
+  ;
+
+#------------------------------------------------------------
+# ATmega168
+#------------------------------------------------------------
+
+part
+    id              = "m168";
+    desc            = "ATmega168";
+     has_debugwire = yes;
+     flash_instr   = 0xB6, 0x01, 0x11;
+     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
+	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+	             0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode  = 0x86;
+    # avr910_devcode = 0x;
+    signature       = 0x1e 0x94 0x06;
+    pagel           = 0xd7;
+    bs2             = 0xc2;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
+                       "x x x x x x x x x x x x x x x x";
+
+    chip_erase       = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
+                       "x x x x x x x x x x x x x x x x";
+
+    timeout         = 200;
+    stabdelay       = 100;
+    cmdexedelay     = 25;
+    synchloops      = 32;
+    bytedelay       = 0;
+    pollindex       = 3;
+    pollvalue       = 0x53;
+    predelay        = 1;
+    postdelay       = 1;
+    pollmethod      = 1;
+
+    pp_controlstack     =
+	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no;
+        page_size       = 4;
+        size            = 512;
+        min_write_delay = 3600;
+        max_write_delay = 3600;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = " 1 0 1 0 0 0 0 0",
+                          " 0 0 0 x x x x a8",
+                          " a7 a6 a5 a4 a3 a2 a1 a0",
+                          " o o o o o o o o";
+    
+        write           = " 1 1 0 0 0 0 0 0",
+                          " 0 0 0 x x x x a8",
+                          " a7 a6 a5 a4 a3 a2 a1 a0",
+                          " i i i i i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x  a8",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+        ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = " 0 0 1 0 0 0 0 0",
+                          " 0 0 0 a12 a11 a10 a9 a8",
+                          " a7 a6 a5 a4 a3 a2 a1 a0",
+                          " o o o o o o o o";
+        
+        read_hi          = " 0 0 1 0 1 0 0 0",
+                           " 0 0 0 a12 a11 a10 a9 a8",
+                           " a7 a6 a5 a4 a3 a2 a1 a0",
+                           " o o o o o o o o";
+        
+        loadpage_lo     = " 0 1 0 0 0 0 0 0",
+                          " 0 0 0 x x x x x",
+                          " x x a5 a4 a3 a2 a1 a0",
+                          " i i i i i i i i";
+        
+        loadpage_hi     = " 0 1 0 0 1 0 0 0",
+                          " 0 0 0 x x x x x",
+                          " x x a5 a4 a3 a2 a1 a0",
+                          " i i i i i i i i";
+        
+        writepage       = " 0 1 0 0 1 1 0 0",
+                          " 0 0 0 a12 a11 a10 a9 a8",
+                          " a7 a6 x x x x x x",
+                          " x x x x x x x x";
+
+        mode        = 0x41;
+        delay       = 6;
+        blocksize   = 128;
+        readsize    = 256;
+
+        ;
+        
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
+                          "x x x x x x x x o o o o o o o o";
+        
+        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
+                          "x x x x x x x x i i i i i i i i";
+        ;
+    
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
+                          "x x x x x x x x o o o o o o o o";
+        
+        write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
+                          "x x x x x x x x i i i i i i i i";
+        ;
+    
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
+                          "x x x x x x x x x x x x x o o o";
+        
+        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
+                          "x x x x x x x x x x x x x i i i";
+        ;
+    
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
+                          "x x x x x x x x x x o o o o o o";
+        
+        write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
+                          "x x x x x x x x 1 1 i i i i i i";
+        ;
+    
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0 o o o o o o o o";
+        ;
+    
+    memory "signature"
+        size            = 3;
+        read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
+                          "x x x x x x a1 a0 o o o o o o o o";
+        ;
+;
+
+#------------------------------------------------------------
+# ATmega168P
+#------------------------------------------------------------
+
+part parent "m168"
+    id              = "m168p";
+    desc            = "ATmega168P";
+    signature       = 0x1e 0x94 0x0b;
+
+    ocdrev              = 1;
+;
+
+#------------------------------------------------------------
+# ATtiny88
+#------------------------------------------------------------
+
+part
+    id               = "t88";
+    desc             = "ATtiny88";
+     has_debugwire = yes;
+     flash_instr   = 0xB6, 0x01, 0x11;
+     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
+	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+	             0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode   = 0x73;
+#    avr910_devcode   = 0x;
+    signature        = 0x1e 0x93 0x11;
+    pagel            = 0xd7;
+    bs2              = 0xc2;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no;
+        page_size       = 4;
+        size            = 64;
+        min_write_delay = 3600;
+        max_write_delay = 3600;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  "  x  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 64;
+      ;
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  0   0   0   0  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  0   0   0   0  a11 a10  a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   0   x      x   x   x   x",
+                          "  x   x   x  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x   i i i i  i i i i";
+      ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x   x x x x  x o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x   x x x x  x x x i";
+      ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
+                          "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega328
+#------------------------------------------------------------
+
+part
+    id			= "m328";
+    desc		= "ATmega328";
+    has_debugwire	= yes;
+    flash_instr		= 0xB6, 0x01, 0x11;
+    eeprom_instr	= 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
+			  0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+			  0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode	= 0x86;
+    # avr910_devcode	= 0x;
+    signature		= 0x1e 0x95 0x14;
+    pagel		= 0xd7;
+    bs2			= 0xc2;
+    chip_erase_delay	= 9000;
+    pgm_enable = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
+		 "x x x x x x x x x x x x x x x x";
+
+    chip_erase = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
+		 "x x x x x x x x x x x x x x x x";
+
+    timeout	= 200;
+    stabdelay	= 100;
+    cmdexedelay	= 25;
+    synchloops	= 32;
+    bytedelay	= 0;
+    pollindex	= 3;
+    pollvalue	= 0x53;
+    predelay	= 1;
+    postdelay	= 1;
+    pollmethod	= 1;
+
+    pp_controlstack =
+	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay	= 100;
+    progmodedelay	= 0;
+    latchcycles		= 5;
+    togglevtg		= 1;
+    poweroffdelay	= 15;
+    resetdelayms	= 1;
+    resetdelayus	= 0;
+    hvleavestabdelay	= 15;
+    resetdelay		= 15;
+    chiperasepulsewidth	= 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+	paged		= no;
+	page_size	= 4;
+	size		= 1024;
+	min_write_delay = 3600;
+	max_write_delay = 3600;
+	readback_p1	= 0xff;
+	readback_p2	= 0xff;
+	read = " 1 0 1 0 0 0 0 0",
+	       " 0 0 0 x x x a9 a8",
+	       " a7 a6 a5 a4 a3 a2 a1 a0",
+	       " o o o o o o o o";
+
+	write = " 1 1 0 0 0 0 0 0",
+	      	" 0 0 0 x x x a9 a8",
+		" a7 a6 a5 a4 a3 a2 a1 a0",
+		" i i i i i i i i";
+
+	loadpage_lo = " 1 1 0 0 0 0 0 1",
+		      " 0 0 0 0 0 0 0 0",
+		      " 0 0 0 0 0 0 a1 a0",
+		      " i i i i i i i i";
+
+	writepage = " 1 1 0 0 0 0 1 0",
+		    " 0 0 x x x x a9 a8",
+		    " a7 a6 a5 a4 a3 a2 0 0",
+		    " x x x x x x x x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+    ;
+
+    memory "flash"
+	paged		= yes;
+	size		= 32768;
+	page_size	= 128;
+	num_pages	= 256;
+	min_write_delay = 4500;
+	max_write_delay = 4500;
+	readback_p1	= 0xff;
+	readback_p2	= 0xff;
+	read_lo = " 0 0 1 0 0 0 0 0",
+		  " 0 0 a13 a12 a11 a10 a9 a8",
+		  " a7 a6 a5 a4 a3 a2 a1 a0",
+		  " o o o o o o o o";
+
+	read_hi = " 0 0 1 0 1 0 0 0",
+		  " 0 0 a13 a12 a11 a10 a9 a8",
+		  " a7 a6 a5 a4 a3 a2 a1 a0",
+		  " o o o o o o o o";
+
+	loadpage_lo = " 0 1 0 0 0 0 0 0",
+		      " 0 0 0 x x x x x",
+		      " x x a5 a4 a3 a2 a1 a0",
+		      " i i i i i i i i";
+
+	loadpage_hi = " 0 1 0 0 1 0 0 0",
+		      " 0 0 0 x x x x x",
+		      " x x a5 a4 a3 a2 a1 a0",
+		      " i i i i i i i i";
+
+	writepage = " 0 1 0 0 1 1 0 0",
+		    " 0 0 a13 a12 a11 a10 a9 a8",
+		    " a7 a6 x x x x x x",
+		    " x x x x x x x x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+
+    ;
+
+    memory "lfuse"
+	size = 1;
+	min_write_delay = 4500;
+	max_write_delay = 4500;
+	read = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
+	       "x x x x x x x x o o o o o o o o";
+
+	write = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
+	      	"x x x x x x x x i i i i i i i i";
+    ;
+
+    memory "hfuse"
+	size = 1;
+	min_write_delay = 4500;
+	max_write_delay = 4500;
+	read = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
+	       "x x x x x x x x o o o o o o o o";
+
+	write = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
+	      	"x x x x x x x x i i i i i i i i";
+    ;
+
+    memory "efuse"
+	size = 1;
+	min_write_delay = 4500;
+	max_write_delay = 4500;
+	read = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
+	       "x x x x x x x x x x x x x o o o";
+
+	write = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
+	      	"x x x x x x x x x x x x x i i i";
+    ;
+
+    memory "lock"
+	size = 1;
+	min_write_delay = 4500;
+	max_write_delay = 4500;
+	read = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
+	       "x x x x x x x x x x o o o o o o";
+
+	write = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
+	      	"x x x x x x x x 1 1 i i i i i i";
+    ;
+
+    memory "calibration"
+	size = 1;
+	read = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
+	       "0 0 0 0 0 0 0 0 o o o o o o o o";
+    ;
+
+    memory "signature"
+	size = 3;
+	read = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
+	       "x x x x x x a1 a0 o o o o o o o o";
+    ;
+;
+
+part parent "m328"
+    id			= "m328p";
+    desc		= "ATmega328P";
+    signature		= 0x1e 0x95 0x0F;
+
+    ocdrev              = 1;
+;
+
+#------------------------------------------------------------
+# ATtiny2313
+#------------------------------------------------------------
+
+part
+     id            = "t2313";
+     desc          = "ATtiny2313";
+     has_debugwire = yes;
+     flash_instr   = 0xB2, 0x0F, 0x1F;
+     eeprom_instr  = 0xBB, 0xFE, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+	             0xBA, 0x0F, 0xB2, 0x0F, 0xBA, 0x0D, 0xBB, 0xBC,
+	             0x99, 0xE1, 0xBB, 0xAC;
+     stk500_devcode   = 0x23;
+##   Use the ATtiny26 devcode:
+     avr910_devcode   = 0x5e;
+     signature        = 0x1e 0x91 0x0a;
+     pagel            = 0xD4;
+     bs2              = 0xD6;
+     reset            = io;
+     chip_erase_delay = 9000;
+
+     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
+        0x4E, 0x5E, 0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E,
+        0x26, 0x36, 0x66, 0x76, 0x2A, 0x3A, 0x6A, 0x7A,
+        0x2E, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 0;
+
+     memory "eeprom"
+         size            = 128;
+        paged           = no;
+        page_size       = 4;
+         min_write_delay = 4000;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
+                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
+                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  "  x  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 4;
+	readsize	= 256;
+       ;
+     memory "flash"
+         paged           = yes;
+         size            = 2048;
+         page_size       = 32;
+         num_pages       = 64;
+         min_write_delay = 4500;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0    0   0  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0    0   0  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+# The information in the data sheet of April/2004 is wrong, this works:
+         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+# The information in the data sheet of April/2004 is wrong, this works:
+         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+# The information in the data sheet of April/2004 is wrong, this works:
+         writepage       = "  0  1  0  0   1  1  0  0",
+                           "  0  0  0  0   0  0 a9 a8",
+                           " a7 a6 a5 a4   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 32;
+	readsize	= 256;
+       ;
+#   ATtiny2313 has Signature Bytes: 0x1E 0x91 0x0A.
+     memory "signature"
+         size            = 3;
+         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+       ;
+     memory "lock"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  1 1 i i  i i i i";
+         read           = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  x x o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "lfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "hfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "efuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+     ;
+# The Tiny2313 has calibration data for both 4 MHz and 8 MHz.
+# The information in the data sheet of April/2004 is wrong, this works:
+
+     memory "calibration"
+         size            = 2;
+         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+     ;
+  ;
+
+#------------------------------------------------------------
+# ATtiny4313
+#------------------------------------------------------------
+
+part
+     id            = "t4313";
+     desc          = "ATtiny4313";
+     has_debugwire = yes;
+     flash_instr   = 0xB2, 0x0F, 0x1F;
+     eeprom_instr  = 0xBB, 0xFE, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+	             0xBA, 0x0F, 0xB2, 0x0F, 0xBA, 0x0D, 0xBB, 0xBC,
+	             0x99, 0xE1, 0xBB, 0xAC;
+     stk500_devcode   = 0x23;
+##   Use the ATtiny26 devcode:
+     avr910_devcode   = 0x5e;
+     signature        = 0x1e 0x92 0x0d;
+     pagel            = 0xD4;
+     bs2              = 0xD6;
+     reset            = io;
+     chip_erase_delay = 9000;
+
+     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
+        0x4E, 0x5E, 0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E,
+        0x26, 0x36, 0x66, 0x76, 0x2A, 0x3A, 0x6A, 0x7A,
+        0x2E, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 0;
+
+     memory "eeprom"
+         size            = 256;
+        paged           = no;
+        page_size       = 4;
+         min_write_delay = 4000;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read            = "1   0  1  0   0  0  0  0   0 0 0 x  x x x x",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+         write           = "1   1  0  0   0  0  0  0   0 0 0 x  x x x x",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 4;
+	readsize	= 256;
+       ;
+     memory "flash"
+         paged           = yes;
+         size            = 4096;
+         page_size       = 64;
+         num_pages       = 64;
+         min_write_delay = 4500;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0    0 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0    0 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         writepage       = "  0  1  0  0   1   1  0  0",
+                           "  0  0  0  0   0 a10 a9 a8",
+                           " a7 a6 a5  x   x   x  x  x",
+                           "  x  x  x  x   x   x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 32;
+	readsize	= 256;
+       ;
+#   ATtiny4313 has Signature Bytes: 0x1E 0x92 0x0D.
+     memory "signature"
+         size            = 3;
+         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+       ;
+     memory "lock"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  1 1 i i  i i i i";
+         read           = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  x x o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "lfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "hfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "efuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+     ;
+
+     memory "calibration"
+         size            = 2;
+         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+     ;
+  ;
+
+#------------------------------------------------------------
+# AT90PWM2
+#------------------------------------------------------------
+
+part
+     id            = "pwm2";
+     desc          = "AT90PWM2";
+     has_debugwire = yes;
+     flash_instr   = 0xB6, 0x01, 0x11;
+     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
+	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+	             0x99, 0xF9, 0xBB, 0xAF;
+     stk500_devcode   = 0x65;
+##  avr910_devcode   = ?;
+     signature        = 0x1e 0x93 0x81;
+     pagel            = 0xD8;
+     bs2              = 0xE2;
+     reset            = io;
+     chip_erase_delay = 9000;
+
+     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+     memory "eeprom"
+         size            = 512;
+        paged           = no;
+        page_size       = 4;
+         min_write_delay = 4000;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x a8",
+                           "a7 a6 a5 a4  a3 a2 a1 a0  o o o o  o o o o";
+
+         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x a8",
+                           "a7 a6 a5 a4  a3 a2 a1 a0  i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 4;
+	readsize	= 256;
+       ;
+     memory "flash"
+         paged           = yes;
+         size            = 8192;
+         page_size       = 64;
+         num_pages       = 128;
+         min_write_delay = 4500;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0   a11 a10 a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0   a11 a10 a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         writepage       = "  0  1  0  0   1   1   0   0",
+                           "  0  0  0  0   a11 a10 a9  a8",
+                           " a7 a6 a5  x   x   x   x   x",
+                           "  x  x  x  x   x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 64;
+	readsize	= 256;
+       ;
+#   AT90PWM2 has Signature Bytes: 0x1E 0x93 0x81.
+     memory "signature"
+         size            = 3;
+         read            = "0  0  1  1   0  0  0  0   0  0  x  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+       ;
+     memory "lock"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  1 1 i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  x x o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "lfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "hfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "efuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+     ;
+
+     memory "calibration"
+         size            = 1;
+         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  0    o o o o  o o o o";
+     ;
+  ;
+
+#------------------------------------------------------------
+# AT90PWM3
+#------------------------------------------------------------
+
+# Completely identical to AT90PWM2 (including the signature!)
+
+part parent "pwm2"
+     id            = "pwm3";
+     desc          = "AT90PWM3";
+  ;
+
+#------------------------------------------------------------
+# AT90PWM2B
+#------------------------------------------------------------
+# Same as AT90PWM2 but different signature.
+
+part parent "pwm2"
+     id            = "pwm2b";
+     desc          = "AT90PWM2B";
+     signature     = 0x1e 0x93 0x83;
+
+    ocdrev              = 1;
+  ;
+
+#------------------------------------------------------------
+# AT90PWM3B
+#------------------------------------------------------------
+
+# Completely identical to AT90PWM2B (including the signature!)
+
+part parent "pwm2b"
+     id            = "pwm3b";
+     desc          = "AT90PWM3B";
+
+    ocdrev              = 1;
+  ;
+
+#------------------------------------------------------------
+# AT90PWM316
+#------------------------------------------------------------
+
+# Similar to AT90PWM3B, but with 16 kiB flash, 512 B EEPROM, and 1024 B SRAM.
+
+part parent "pwm3b"
+     id            = "pwm316";
+     desc          = "AT90PWM316";
+     signature     = 0x1e 0x94 0x83;
+
+    ocdrev              = 1;
+
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0   0 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATtiny25
+#------------------------------------------------------------
+
+part
+     id            = "t25";
+     desc          = "ATtiny25";
+     has_debugwire = yes;
+     flash_instr   = 0xB4, 0x02, 0x12;
+     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+	             0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
+	             0x99, 0xE1, 0xBB, 0xAC;
+## no STK500 devcode in XML file, use the ATtiny45 one
+     stk500_devcode   = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+     avr910_devcode   = 0x20;
+     signature        = 0x1e 0x91 0x08;
+     reset            = io;
+     chip_erase_delay = 4500;
+
+     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
+        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    hventerstabdelay    = 100;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    ocdrev              = 1;
+
+     memory "eeprom"
+         size            = 128;
+        paged           = no;
+        page_size       = 4;
+         min_write_delay = 4000;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
+                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
+                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  "  x  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 4;
+	readsize	= 256;
+       ;
+     memory "flash"
+         paged           = yes;
+         size            = 2048;
+         page_size       = 32;
+         num_pages       = 64;
+         min_write_delay = 4500;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0    0   0  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0    0   0  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         writepage       = "  0  1  0  0   1  1  0  0",
+                           "  0  0  0  0   0  0 a9 a8",
+                           " a7 a6 a5 a4   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 32;
+	readsize	= 256;
+       ;
+#   ATtiny25 has Signature Bytes: 0x1E 0x91 0x08.
+     memory "signature"
+         size            = 3;
+         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+       ;
+     memory "lock"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "lfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "hfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "efuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+     ;
+
+     memory "calibration"
+         size            = 2;
+         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+     ;
+  ;
+
+#------------------------------------------------------------
+# ATtiny45
+#------------------------------------------------------------
+
+part
+     id            = "t45";
+     desc          = "ATtiny45";
+     has_debugwire = yes;
+     flash_instr   = 0xB4, 0x02, 0x12;
+     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+	             0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
+	             0x99, 0xE1, 0xBB, 0xAC;
+     stk500_devcode   = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+     avr910_devcode   = 0x20;
+     signature        = 0x1e 0x92 0x06;
+     reset            = io;
+     chip_erase_delay = 4500;
+
+     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    hvsp_controlstack     =
+	0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
+        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    ocdrev              = 1;
+
+     memory "eeprom"
+         size            = 256;
+         page_size       = 4;
+         min_write_delay = 4000;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 4;
+	readsize	= 256;
+       ;
+     memory "flash"
+         paged           = yes;
+         size            = 4096;
+         page_size       = 64;
+         num_pages       = 64;
+         min_write_delay = 4500;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0    0  a10 a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0    0  a10 a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         writepage       = "  0  1  0  0   1  1  0  0",
+                           "  0  0  0  0   0 a10 a9 a8",
+                           " a7 a6 a5  x   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 32;
+	readsize	= 256;
+       ;
+#   ATtiny45 has Signature Bytes: 0x1E 0x92 0x08. (Data sheet 2586C-AVR-06/05 (doc2586.pdf) indicates otherwise!)
+     memory "signature"
+         size            = 3;
+         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+       ;
+     memory "lock"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "lfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "hfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "efuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+     ;
+
+     memory "calibration"
+         size            = 2;
+         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+     ;
+  ;
+
+#------------------------------------------------------------
+# ATtiny85
+#------------------------------------------------------------
+
+part
+     id            = "t85";
+     desc          = "ATtiny85";
+     has_debugwire = yes;
+     flash_instr   = 0xB4, 0x02, 0x12;
+     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+	             0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
+	             0x99, 0xE1, 0xBB, 0xAC;
+## no STK500 devcode in XML file, use the ATtiny45 one
+     stk500_devcode   = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+     avr910_devcode   = 0x20;
+     signature        = 0x1e 0x93 0x0b;
+     reset            = io;
+     chip_erase_delay = 400000;
+
+     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
+        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    hventerstabdelay    = 100;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    ocdrev              = 1;
+
+     memory "eeprom"
+         size            = 512;
+        paged           = no;
+        page_size       = 4;
+         min_write_delay = 4000;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x a8",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x a8",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x  a8",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 12;
+	blocksize	= 4;
+	readsize	= 256;
+       ;
+     memory "flash"
+         paged           = yes;
+         size            = 8192;
+         page_size       = 64;
+         num_pages       = 128;
+         min_write_delay = 30000;
+         max_write_delay = 30000;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         writepage       = "  0  1  0  0   1   1   0  0",
+                           "  0  0  0  0  a11 a10 a9 a8",
+                           " a7 a6 a5  x   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 32;
+	readsize	= 256;
+       ;
+#   ATtiny85 has Signature Bytes: 0x1E 0x93 0x08.
+     memory "signature"
+         size            = 3;
+         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+       ;
+     memory "lock"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "lfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "hfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "efuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+     ;
+
+     memory "calibration"
+         size            = 2;
+         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+     ;
+  ;
+
+#------------------------------------------------------------
+# ATmega640
+#------------------------------------------------------------
+# Almost same as ATmega1280, except for different memory sizes
+
+part
+    id               = "m640";
+    desc             = "ATmega640";
+    signature        = 0x1e 0x96 0x08;
+    has_jtag         = yes;
+#    stk500_devcode   = 0xB2;
+#    avr910_devcode   = 0x43;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    rampz               = 0x3b;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 4096;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x    a11 a10  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 8;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 65536;
+        page_size       = 256;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  x i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega1280
+#------------------------------------------------------------
+
+part
+    id               = "m1280";
+    desc             = "ATmega1280";
+    signature        = 0x1e 0x97 0x03;
+    has_jtag         = yes;
+#    stk500_devcode   = 0xB2;
+#    avr910_devcode   = 0x43;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    rampz               = 0x3b;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 4096;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x    a11 a10  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 8;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 131072;
+        page_size       = 256;
+        num_pages       = 512;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  x i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega1281
+#------------------------------------------------------------
+# Identical to ATmega1280
+
+part parent "m1280"
+    id               = "m1281";
+    desc             = "ATmega1281";
+    signature        = 0x1e 0x97 0x04;
+
+    ocdrev              = 3;
+  ;
+
+#------------------------------------------------------------
+# ATmega2560
+#------------------------------------------------------------
+
+part
+    id               = "m2560";
+    desc             = "ATmega2560";
+    signature        = 0x1e 0x98 0x01;
+    has_jtag         = yes;
+#    stk500_devcode   = 0xB2;
+#    avr910_devcode   = 0x43;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    rampz               = 0x3b;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 4;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 4096;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x    a11 a10  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 8;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 262144;
+        page_size       = 256;
+        num_pages       = 1024;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+        load_ext_addr   = "  0   1   0   0      1   1   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0   0 a16",
+                          "  0   0   0   0      0   0   0   0";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  x i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega2561
+#------------------------------------------------------------
+
+part parent "m2560"
+    id               = "m2561";
+    desc             = "ATmega2561";
+    signature        = 0x1e 0x98 0x02;
+
+    ocdrev              = 4;
+  ;
+
+#------------------------------------------------------------
+# ATmega128RFA1
+#------------------------------------------------------------
+# Identical to ATmega2561 but half the ROM
+
+part parent "m2561"
+    id               = "m128rfa1";
+    desc             = "ATmega128RFA1";
+    signature        = 0x1e 0xa7 0x01;
+    chip_erase_delay = 55000;
+    bs2              = 0xE2;
+
+    ocdrev              = 3;
+
+    memory "flash"
+        paged           = yes;
+        size            = 131072;
+        page_size       = 256;
+        num_pages       = 512;
+        min_write_delay = 50000;
+        max_write_delay = 50000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega256RFR2
+#------------------------------------------------------------
+
+part parent "m2561"
+    id               = "m256rfr2";
+    desc             = "ATmega256RFR2";
+    signature        = 0x1e 0xa8 0x02;
+    chip_erase_delay = 55000;
+    bs2              = 0xE2;
+
+
+    ocdrev              = 4;
+  ;
+
+#------------------------------------------------------------
+# ATmega128RFR2
+#------------------------------------------------------------
+
+part parent "m128rfa1"
+    id               = "m128rfr2";
+    desc             = "ATmega128RFR2";
+    signature        = 0x1e 0xa7 0x02;
+
+
+    ocdrev              = 3;
+  ;
+
+#------------------------------------------------------------
+# ATmega64RFR2
+#------------------------------------------------------------
+
+part parent "m128rfa1"
+    id               = "m64rfr2";
+    desc             = "ATmega64RFR2";
+    signature        = 0x1e 0xa6 0x02;
+
+
+    ocdrev              = 3;
+
+    memory "flash"
+        paged           = yes;
+        size            = 65536;
+        page_size       = 256;
+        num_pages       = 256;
+        min_write_delay = 50000;
+        max_write_delay = 50000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega2564RFR2
+#------------------------------------------------------------
+
+part parent "m256rfr2"
+    id               = "m2564rfr2";
+    desc             = "ATmega2564RFR2";
+    signature        = 0x1e 0xa8 0x03;
+  ;
+
+#------------------------------------------------------------
+# ATmega1284RFR2
+#------------------------------------------------------------
+
+part parent "m128rfr2"
+    id               = "m1284rfr2";
+    desc             = "ATmega1284RFR2";
+    signature        = 0x1e 0xa7 0x03;
+  ;
+
+#------------------------------------------------------------
+# ATmega644RFR2
+#------------------------------------------------------------
+
+part parent "m64rfr2"
+    id               = "m644rfr2";
+    desc             = "ATmega644RFR2";
+    signature        = 0x1e 0xa6 0x03;
+  ;
+
+#------------------------------------------------------------
+# ATtiny24
+#------------------------------------------------------------
+
+part
+     id            = "t24";
+     desc          = "ATtiny24";
+     has_debugwire = yes;
+     flash_instr   = 0xB4, 0x07, 0x17;
+     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+	             0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
+	             0x99, 0xE1, 0xBB, 0xAC;
+## no STK500 devcode in XML file, use the ATtiny45 one
+     stk500_devcode   = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+     avr910_devcode   = 0x20;
+     signature        = 0x1e 0x91 0x0b;
+     reset            = io;
+     chip_erase_delay = 4500;
+
+     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
+        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
+    hventerstabdelay    = 100;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 0;
+    resetdelayus        = 70;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    ocdrev              = 1;
+
+     memory "eeprom"
+         size            = 128;
+        paged           = no;
+        page_size       = 4;
+         min_write_delay = 4000;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
+                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
+                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  "  x  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 4;
+	readsize	= 256;
+       ;
+     memory "flash"
+         paged           = yes;
+         size            = 2048;
+         page_size       = 32;
+         num_pages       = 64;
+         min_write_delay = 4500;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0    0   0  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0    0   0  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         writepage       = "  0  1  0  0   1  1  0  0",
+                           "  0  0  0  0   0  0 a9 a8",
+                           " a7 a6 a5 a4   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 32;
+	readsize	= 256;
+       ;
+#   ATtiny24 has Signature Bytes: 0x1E 0x91 0x0B.
+     memory "signature"
+         size            = 3;
+         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+       ;
+     memory "lock"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  x x x x  x x i i";
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "lfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "hfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "efuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+     ;
+
+     memory "calibration"
+         size            = 1;
+         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+     ;
+  ;
+
+#------------------------------------------------------------
+# ATtiny44
+#------------------------------------------------------------
+
+part
+     id            = "t44";
+     desc          = "ATtiny44";
+     has_debugwire = yes;
+     flash_instr   = 0xB4, 0x07, 0x17;
+     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+                     0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
+## no STK500 devcode in XML file, use the ATtiny45 one
+     stk500_devcode   = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+     avr910_devcode   = 0x20;
+     signature        = 0x1e 0x92 0x07;
+     reset            = io;
+     chip_erase_delay = 4500;
+
+     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
+        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
+    hventerstabdelay    = 100;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 0;
+    resetdelayus        = 70;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    ocdrev              = 1;
+
+     memory "eeprom"
+         size            = 256;
+        paged           = no;
+        page_size       = 4;
+         min_write_delay = 4000;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  "  x  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 4;
+	readsize	= 256;
+       ;
+     memory "flash"
+         paged           = yes;
+         size            = 4096;
+         page_size       = 64;
+         num_pages       = 64;
+         min_write_delay = 4500;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0    0  a10 a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0    0  a10 a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         writepage       = "  0  1  0  0   1  1  0  0",
+                           "  0  0  0  0   0 a10 a9 a8",
+                           " a7 a6 a5  x   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 32;
+	readsize	= 256;
+       ;
+#   ATtiny44 has Signature Bytes: 0x1E 0x92 0x07.
+     memory "signature"
+         size            = 3;
+         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+       ;
+     memory "lock"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  x x x x  x x i i";
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "lfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "hfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "efuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+     ;
+
+     memory "calibration"
+         size            = 1;
+         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+     ;
+  ;
+
+#------------------------------------------------------------
+# ATtiny84
+#------------------------------------------------------------
+
+part
+     id            = "t84";
+     desc          = "ATtiny84";
+     has_debugwire = yes;
+     flash_instr   = 0xB4, 0x07, 0x17;
+     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+	             0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
+	             0x99, 0xE1, 0xBB, 0xAC;
+## no STK500 devcode in XML file, use the ATtiny45 one
+     stk500_devcode   = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+     avr910_devcode   = 0x20;
+     signature        = 0x1e 0x93 0x0c;
+     reset            = io;
+     chip_erase_delay = 4500;
+
+     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
+        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
+    hventerstabdelay    = 100;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 0;
+    resetdelayus        = 70;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    ocdrev              = 1;
+
+     memory "eeprom"
+         size            = 512;
+        paged           = no;
+        page_size       = 4;
+         min_write_delay = 4000;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x a8",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x a8",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   x   x   x",
+			  "  x  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 4;
+	readsize	= 256;
+       ;
+     memory "flash"
+         paged           = yes;
+         size            = 8192;
+         page_size       = 64;
+         num_pages       = 128;
+         min_write_delay = 4500;
+         max_write_delay = 4500;
+         readback_p1     = 0xff;
+         readback_p2     = 0xff;
+         read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+         writepage       = "  0  1  0  0   1   1   0  0",
+                           "  0  0  0  0  a11 a10 a9 a8",
+                           " a7 a6 a5  x   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 32;
+	readsize	= 256;
+       ;
+#   ATtiny84 has Signature Bytes: 0x1E 0x93 0x0C.
+     memory "signature"
+         size            = 3;
+         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+       ;
+
+     memory "lock"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  x x x x  x x i i";
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "lfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "hfuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+       ;
+
+     memory "efuse"
+         size            = 1;
+         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+     ;
+
+     memory "calibration"
+         size            = 1;
+         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+     ;
+  ;
+
+#------------------------------------------------------------
+# ATtiny43U
+#------------------------------------------------------------
+
+part
+    id            = "t43u";
+    desc          = "ATtiny43u";
+    has_debugwire = yes;
+    flash_instr   = 0xB4, 0x07, 0x17;
+    eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+                         0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
+                         0x99, 0xE1, 0xBB, 0xAC;
+    stk500_devcode   = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+    avr910_devcode   = 0x20;
+    signature        = 0x1e 0x92 0x0C;
+    reset            = io;
+    chip_erase_delay = 1000;
+
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout                     = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+        pp_controlstack = 0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E, 0x4E, 0x5E,
+                                         0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E, 0x06, 0x16, 0x46, 0x56,
+                                         0x0A, 0x1A, 0x4A, 0x5A, 0x1E, 0x7C, 0x00, 0x01, 0x00, 0x00,
+                                         0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    hvspcmdexedelay     = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 20;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+    memory "eeprom"
+                size            = 64;
+                paged                   = yes;
+                page_size       = 4;
+                num_pages               = 16;
+                min_write_delay = 4000;
+                max_write_delay = 4500;
+                readback_p1     = 0xff;
+                readback_p2     = 0xff;
+                read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
+                                   "0  0 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+                write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
+                                   "0  0 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+                loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                                  "  0   0   0   0      0   0   0   0",
+                                  "  0   0   0   0      0   0  a1  a0",
+                                  "  i   i   i   i      i   i   i   i";
+
+                writepage       = "  1   1   0   0      0   0   1   0",
+                                  "  0   0   x   x      x   x   x   x",
+                                  "  0   0  a5  a4     a3  a2   0   0",
+                                  "  x   x   x   x      x   x   x   x";
+
+                mode            = 0x41;
+                delay           = 5;
+                blocksize       = 4;
+                readsize        = 256;
+        ;
+    memory "flash"
+        paged           = yes;
+        size            = 4096;
+        page_size       = 64;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                          "  0   0   0   0    0  a10 a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                          "  0   0   0   0    0  a10 a9  a8",
+                          " a7  a6  a5  a4   a3  a2  a1  a0",
+                          "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                          "  0   0   0   x    x   x   x   x",
+                          "  x   x   x  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                          "  0   0   0   x    x   x   x   x",
+                          "  x   x   x  a4   a3  a2  a1  a0",
+                          "  i   i   i   i    i   i   i   i";
+
+        writepage       = "  0  1  0  0   1  1  0  0",
+                          "  0  0  0  0   0 a10 a9 a8",
+                          " a7 a6 a5  x   x  x  x  x",
+                          "  x  x  x  x   x  x  x  x";
+
+                mode            = 0x41;
+                delay           = 10;
+                blocksize       = 64;
+                readsize        = 256;
+       ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+    ;
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                          "x x x x  x x x x  1 1 i i  i i i i";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  x x x i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+    ;
+
+    memory "calibration"
+        size            = 2;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                          "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega32u4
+#------------------------------------------------------------
+
+part
+    id               = "m32u4";
+    desc             = "ATmega32U4";
+    signature        = 0x1e 0x95 0x87;
+    has_jtag         = yes;
+#    stk500_devcode   = 0xB2;
+#    avr910_devcode   = 0x43;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    rampz               = 0x3b;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 1024;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x a10  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 32768;
+        page_size       = 128;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          " a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90USB646
+#------------------------------------------------------------
+
+part
+    id               = "usb646";
+    desc             = "AT90USB646";
+    signature        = 0x1e 0x96 0x82;
+    has_jtag         = yes;
+#    stk500_devcode   = 0xB2;
+#    avr910_devcode   = 0x43;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    rampz               = 0x3b;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 2048;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x a10  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 8;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 65536;
+        page_size       = 256;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90USB647
+#------------------------------------------------------------
+# identical to AT90USB646
+
+part parent "usb646"
+    id               = "usb647";
+    desc             = "AT90USB647";
+    signature        = 0x1e 0x96 0x82;
+
+    ocdrev              = 3;
+  ;
+
+#------------------------------------------------------------
+# AT90USB1286
+#------------------------------------------------------------
+
+part
+    id               = "usb1286";
+    desc             = "AT90USB1286";
+    signature        = 0x1e 0x97 0x82;
+    has_jtag         = yes;
+#    stk500_devcode   = 0xB2;
+#    avr910_devcode   = 0x43;
+    chip_erase_delay = 9000;
+    pagel            = 0xD7;
+    bs2              = 0xA0;
+    reset            = dedicated;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "x x x x  x x x x    x x x x  x x x x";
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    rampz               = 0x3b;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 4096;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  x   x   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0  a2  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x a10  a9  a8",
+			  " a7  a6  a5  a4     a3   0   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 8;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 131072;
+        page_size       = 256;
+        num_pages       = 512;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7   x   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  x x x x  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90USB1287
+#------------------------------------------------------------
+# identical to AT90USB1286
+
+part parent "usb1286"
+    id               = "usb1287";
+    desc             = "AT90USB1287";
+    signature        = 0x1e 0x97 0x82;
+
+    ocdrev              = 3;
+  ;
+
+#------------------------------------------------------------
+# AT90USB162
+#------------------------------------------------------------
+
+part
+    id               = "usb162";
+    desc             = "AT90USB162";
+    has_jtag         = no;
+    has_debugwire    = yes;
+    signature        = 0x1e 0x94 0x82;
+    chip_erase_delay = 9000;
+    reset            = io;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+    pagel            = 0xD7;
+    bs2              = 0xC6;
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 512;
+        num_pages       = 128;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# AT90USB82
+#------------------------------------------------------------
+# Changes against AT90USB162 (beside IDs)
+#    memory "flash"
+#        size            = 8192;
+#        num_pages       = 64;
+
+part
+    id               = "usb82";
+    desc             = "AT90USB82";
+    has_jtag         = no;
+    has_debugwire    = yes;
+    signature        = 0x1e 0x93 0x82;
+    chip_erase_delay = 9000;
+    reset            = io;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+    pagel            = 0xD7;
+    bs2              = 0xC6;
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 512;
+        num_pages       = 128;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 128;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega32U2
+#------------------------------------------------------------
+# Changes against AT90USB162 (beside IDs)
+#    memory "flash"
+#        size            = 32768;
+#        num_pages       = 256;
+#    memory "eeprom"
+#        size            = 1024;
+#        num_pages       = 256;
+part
+    id               = "m32u2";
+    desc             = "ATmega32U2";
+    has_jtag         = no;
+    has_debugwire    = yes;
+    signature        = 0x1e 0x95 0x8a;
+    chip_erase_delay = 9000;
+    reset            = io;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+    pagel            = 0xD7;
+    bs2              = 0xC6;
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 1024;
+        num_pages       = 256;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 32768;
+        page_size       = 128;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+#------------------------------------------------------------
+# ATmega16U2
+#------------------------------------------------------------
+# Changes against ATmega32U2 (beside IDs)
+#    memory "flash"
+#        size            = 16384;
+#        num_pages       = 128;
+#    memory "eeprom"
+#        size            = 512;
+#        num_pages       = 128;
+part
+    id               = "m16u2";
+    desc             = "ATmega16U2";
+    has_jtag         = no;
+    has_debugwire    = yes;
+    signature        = 0x1e 0x94 0x89;
+    chip_erase_delay = 9000;
+    reset            = io;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+    pagel            = 0xD7;
+    bs2              = 0xC6;
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 512;
+        num_pages       = 128;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+
+#------------------------------------------------------------
+# ATmega8U2
+#------------------------------------------------------------
+# Changes against ATmega16U2 (beside IDs)
+#    memory "flash"
+#        size            = 8192;
+#        page_size       = 64;
+#        blocksize       = 64;
+
+part
+    id               = "m8u2";
+    desc             = "ATmega8U2";
+    has_jtag         = no;
+    has_debugwire    = yes;
+    signature        = 0x1e 0x93 0x89;
+    chip_erase_delay = 9000;
+    reset            = io;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "x x x x  x x x x    x x x x  x x x x";
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                       "x x x x  x x x x    x x x x  x x x x";
+    pagel            = 0xD7;
+    bs2              = 0xC6;
+
+    timeout		= 200;
+    stabdelay		= 100;
+    cmdexedelay		= 25;
+    synchloops		= 32;
+    bytedelay		= 0;
+    pollindex		= 3;
+    pollvalue		= 0x53;
+    predelay		= 1;
+    postdelay		= 1;
+    pollmethod		= 1;
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 512;
+        num_pages       = 128;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+                          "  0   0   0   0    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0x00;
+        readback_p2     = 0x00;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  x   x   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "a15 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 64;
+	readsize	= 256;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
+                          "x x x x  x x x x   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
+                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+      ;
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+      ;
+  ;
+#------------------------------------------------------------
+# ATmega325
+#------------------------------------------------------------
+
+part
+    id               = "m325";
+    desc             = "ATmega325";
+    signature        = 0x1e 0x95 0x05;
+    has_jtag         = yes;
+#   stk500_devcode   = 0x??; # No STK500v1 support?
+#   avr910_devcode   = 0x??; # Try the ATmega16 one
+    avr910_devcode   = 0x74;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
+
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
+        size            = 1024;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   0   0      0   0  a9  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
+
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 4;
+        readsize        = 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 32768;
+        page_size       = 128;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0   0   0",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   0   0      0   0   0   0",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0 a14 a13 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  x   x   x   x      x   x   x   x";
+
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 0  0 0 0 0",
+                          "0 0 0 0  0 0 0 0   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "0 0 0 0  0 0 0 0  1 1 1 1  1 i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  0   0  0  0  0",
+                          "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "calibration"
+        size            = 1;
+
+        read            = "0 0 1 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        ;
+  ;
+
+#------------------------------------------------------------
+# ATmega645
+#------------------------------------------------------------
+
+part
+    id               = "m645";
+    desc             = "ATmega645";
+    signature        = 0x1E 0x96 0x05;
+    has_jtag         = yes;
+#   stk500_devcode   = 0x??; # No STK500v1 support?
+#   avr910_devcode   = 0x??; # Try the ATmega16 one
+    avr910_devcode   = 0x74;
+    pagel            = 0xd7;
+    bs2              = 0xa0;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
+
+    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
+
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    allowfullpagebitstream = no;
+
+    ocdrev              = 3;
+
+    memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 8;  /* for parallel programming */
+        size            = 2048;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   0   0      0 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   0   0      0 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   0   0      0 a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
+
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+      ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 65536;
+        page_size       = 256;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "   0   0   1   0      0   0   0   0",
+                          " a15 a14 a13 a12    a11 a10  a9  a8",
+                          "  a7  a6  a5  a4     a3  a2  a1  a0",
+                          "   o   o   o   o      o   o   o   o";
+
+        read_hi         = "   0   0   1   0      1   0   0   0",
+                          " a15 a14 a13 a12    a11 a10  a9  a8",
+                          "  a7  a6  a5  a4     a3  a2  a1  a0",
+                          "   o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0   0   0",
+                          "  a7 a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   0   0      0   0   0   0",
+                          "  a7 a6  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "   0   1   0   0      1   1   0   0",
+                          " a15 a14 a13 a12    a11 a10  a9  a8",
+                          "  a7  a6  a5  a4     a3  a2  a1  a0",
+                          "   0   0   0   0      0   0   0   0";
+
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+      ;
+
+    memory "lock"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 1 1 0  0 0 0 0",
+                          "0 0 0 0  0 0 0 0   1 1 i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "lfuse"
+        size            = 1;
+        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
+                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "hfuse"
+        size            = 1;
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
+                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "efuse"
+        size            = 1;
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
+
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                          "0 0 0 0  0 0 0 0  1 1 1 1  1 i i i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+      ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  0   0  0  0  0",
+                          "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
+      ;
+
+    memory "calibration"
+        size            = 1;
+
+        read            = "0 0 1 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        ;
+  ;
+
+#------------------------------------------------------------
+# ATmega3250
+#------------------------------------------------------------
+
+part parent "m325"
+    id               = "m3250";
+    desc             = "ATmega3250";
+    signature        = 0x1E 0x95 0x06;
+
+    ocdrev              = 3;
+  ;
+
+#------------------------------------------------------------
+# ATmega6450
+#------------------------------------------------------------
+
+part parent "m645"
+    id               = "m6450";
+    desc             = "ATmega6450";
+    signature        = 0x1E 0x96 0x06;
+
+    ocdrev              = 3;
+  ;
+
+#------------------------------------------------------------
+# AVR XMEGA family common values
+#------------------------------------------------------------
+
+part
+    id		= ".xmega";
+    desc	= "AVR XMEGA family common values";
+    has_pdi	= yes;
+    nvm_base	= 0x01c0;
+    mcu_base	= 0x0090;
+
+    memory "signature"
+        size		= 3;
+        offset		= 0x1000090;
+    ;
+
+    memory "prodsig"
+        size		= 0x32;
+        offset		= 0x8e0200;
+        page_size	= 0x32;
+        readsize	= 0x32;
+    ;
+
+    memory "fuse1"
+        size		= 1;
+        offset		= 0x8f0021;
+    ;
+
+    memory "fuse2"
+        size		= 1;
+        offset		= 0x8f0022;
+    ;
+
+    memory "fuse4"
+        size		= 1;
+        offset		= 0x8f0024;
+    ;
+
+    memory "fuse5"
+        size		= 1;
+        offset		= 0x8f0025;
+    ;
+
+    memory "lock"
+        size		= 1;
+        offset		= 0x8f0027;
+    ;
+
+    memory "data"
+        # SRAM, only used to supply the offset
+        offset		= 0x1000000;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega16A4U
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x16a4u";
+    desc	= "ATxmega16A4U";
+    signature	= 0x1e 0x94 0x41;
+
+    memory "eeprom"
+        size		= 0x400;
+        offset		= 0x8c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x4000;
+        offset		= 0x800000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x1000;
+        offset		= 0x803000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x1000;
+        offset		= 0x804000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x5000;
+        offset		= 0x800000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size		= 0x100;
+        offset		= 0x8e0400;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega16C4
+#------------------------------------------------------------
+
+part parent "x16a4u"
+    id		= "x16c4";
+    desc	= "ATxmega16C4";
+    signature	= 0x1e 0x95 0x44;
+;
+
+#------------------------------------------------------------
+# ATxmega16D4
+#------------------------------------------------------------
+
+part parent "x16a4u"
+    id		= "x16d4";
+    desc	= "ATxmega16D4";
+    signature	= 0x1e 0x94 0x42;
+;
+
+#------------------------------------------------------------
+# ATxmega16A4
+#------------------------------------------------------------
+
+part parent "x16a4u"
+    id		= "x16a4";
+    desc	= "ATxmega16A4";
+    signature	= 0x1e 0x94 0x41;
+    has_jtag	= yes;
+
+    memory "fuse0"
+        size		= 1;
+        offset		= 0x8f0020;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega32A4U
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x32a4u";
+    desc	= "ATxmega32A4U";
+    signature	= 0x1e 0x95 0x41;
+
+    memory "eeprom"
+        size		= 0x400;
+        offset		= 0x8c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x8000;
+        offset		= 0x800000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x1000;
+        offset		= 0x807000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x1000;
+        offset		= 0x808000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x9000;
+        offset		= 0x800000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size		= 0x100;
+        offset		= 0x8e0400;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega32C4
+#------------------------------------------------------------
+
+part parent "x32a4u"
+    id		= "x32c4";
+    desc	= "ATxmega32C4";
+    signature	= 0x1e 0x94 0x43;
+;
+
+#------------------------------------------------------------
+# ATxmega32D4
+#------------------------------------------------------------
+
+part parent "x32a4u"
+    id		= "x32d4";
+    desc	= "ATxmega32D4";
+    signature	= 0x1e 0x95 0x42;
+;
+
+#------------------------------------------------------------
+# ATxmega32A4
+#------------------------------------------------------------
+
+part parent "x32a4u"
+    id		= "x32a4";
+    desc	= "ATxmega32A4";
+    signature	= 0x1e 0x95 0x41;
+    has_jtag	= yes;
+
+    memory "fuse0"
+        size		= 1;
+        offset		= 0x8f0020;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega64A4U
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x64a4u";
+    desc	= "ATxmega64A4U";
+    signature	= 0x1e 0x96 0x46;
+
+    memory "eeprom"
+        size		= 0x800;
+        offset		= 0x8c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x10000;
+        offset		= 0x800000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x1000;
+        offset		= 0x80f000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x1000;
+        offset		= 0x810000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x11000;
+        offset		= 0x800000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size		= 0x100;
+        offset		= 0x8e0400;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega64C3
+#------------------------------------------------------------
+
+part parent "x64a4u"
+    id		= "x64c3";
+    desc	= "ATxmega64C3";
+    signature	= 0x1e 0x96 0x49;
+;
+
+#------------------------------------------------------------
+# ATxmega64D3
+#------------------------------------------------------------
+
+part parent "x64a4u"
+    id		= "x64d3";
+    desc	= "ATxmega64D3";
+    signature	= 0x1e 0x96 0x4a;
+;
+
+#------------------------------------------------------------
+# ATxmega64D4
+#------------------------------------------------------------
+
+part parent "x64a4u"
+    id		= "x64d4";
+    desc	= "ATxmega64D4";
+    signature	= 0x1e 0x96 0x47;
+;
+
+#------------------------------------------------------------
+# ATxmega64A1
+#------------------------------------------------------------
+
+part parent "x64a4u"
+    id		= "x64a1";
+    desc	= "ATxmega64A1";
+    signature	= 0x1e 0x96 0x4e;
+    has_jtag	= yes;
+
+    memory "fuse0"
+        size		= 1;
+        offset		= 0x8f0020;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega64A1U
+#------------------------------------------------------------
+
+part parent "x64a1"
+    id		= "x64a1u";
+    desc	= "ATxmega64A1U";
+    signature	= 0x1e 0x96 0x4e;
+;
+
+#------------------------------------------------------------
+# ATxmega64A3
+#------------------------------------------------------------
+
+part parent "x64a1"
+    id		= "x64a3";
+    desc	= "ATxmega64A3";
+    signature	= 0x1e 0x96 0x42;
+;
+
+#------------------------------------------------------------
+# ATxmega64A3U
+#------------------------------------------------------------
+
+part parent "x64a1"
+    id		= "x64a3u";
+    desc	= "ATxmega64A3U";
+    signature	= 0x1e 0x96 0x42;
+;
+
+#------------------------------------------------------------
+# ATxmega64A4
+#------------------------------------------------------------
+
+part parent "x64a1"
+    id		= "x64a4";
+    desc	= "ATxmega64A4";
+    signature	= 0x1e 0x96 0x46;
+;
+
+#------------------------------------------------------------
+# ATxmega64B1
+#------------------------------------------------------------
+
+part parent "x64a1"
+    id		= "x64b1";
+    desc	= "ATxmega64B1";
+    signature	= 0x1e 0x96 0x52;
+;
+
+#------------------------------------------------------------
+# ATxmega64B3
+#------------------------------------------------------------
+
+part parent "x64a1"
+    id		= "x64b3";
+    desc	= "ATxmega64B3";
+    signature	= 0x1e 0x96 0x51;
+;
+
+#------------------------------------------------------------
+# ATxmega128C3
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x128c3";
+    desc	= "ATxmega128C3";
+    signature	= 0x1e 0x97 0x52;
+
+    memory "eeprom"
+        size		= 0x800;
+        offset		= 0x8c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x20000;
+        offset		= 0x800000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x2000;
+        offset		= 0x81e000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x2000;
+        offset		= 0x820000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x22000;
+        offset		= 0x800000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size		= 0x200;
+        offset		= 0x8e0400;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega128D3
+#------------------------------------------------------------
+
+part parent "x128c3"
+    id		= "x128d3";
+    desc	= "ATxmega128D3";
+    signature	= 0x1e 0x97 0x48;
+;
+
+#------------------------------------------------------------
+# ATxmega128D4
+#------------------------------------------------------------
+
+part parent "x128c3"
+    id		= "x128d4";
+    desc	= "ATxmega128D4";
+    signature	= 0x1e 0x97 0x47;
+;
+
+#------------------------------------------------------------
+# ATxmega128A1
+#------------------------------------------------------------
+
+part parent "x128c3"
+    id		= "x128a1";
+    desc	= "ATxmega128A1";
+    signature	= 0x1e 0x97 0x4c;
+    has_jtag	= yes;
+
+    memory "fuse0"
+        size		= 1;
+        offset		= 0x8f0020;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega128A1 revision D
+#------------------------------------------------------------
+
+part parent "x128a1"
+    id		= "x128a1d";
+    desc	= "ATxmega128A1revD";
+    signature	= 0x1e 0x97 0x41;
+;
+
+#------------------------------------------------------------
+# ATxmega128A1U
+#------------------------------------------------------------
+
+part parent "x128a1"
+    id		= "x128a1u";
+    desc	= "ATxmega128A1U";
+    signature	= 0x1e 0x97 0x4c;
+;
+
+#------------------------------------------------------------
+# ATxmega128A3
+#------------------------------------------------------------
+
+part parent "x128a1"
+    id		= "x128a3";
+    desc	= "ATxmega128A3";
+    signature	= 0x1e 0x97 0x42;
+;
+
+#------------------------------------------------------------
+# ATxmega128A3U
+#------------------------------------------------------------
+
+part parent "x128a1"
+    id		= "x128a3u";
+    desc	= "ATxmega128A3U";
+    signature	= 0x1e 0x97 0x42;
+;
+
+#------------------------------------------------------------
+# ATxmega128A4
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x128a4";
+    desc	= "ATxmega128A4";
+    signature	= 0x1e 0x97 0x46;
+    has_jtag	= yes;
+
+    memory "eeprom"
+        size		= 0x800;
+        offset		= 0x8c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x20000;
+        offset		= 0x800000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x1000;
+        offset		= 0x81f000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x2000;
+        offset		= 0x820000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x22000;
+        offset		= 0x800000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size		= 0x200;
+        offset		= 0x8e0400;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "fuse0"
+        size		= 1;
+        offset		= 0x8f0020;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega128A4U
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x128a4u";
+    desc	= "ATxmega128A4U";
+    signature	= 0x1e 0x97 0x46;
+
+    memory "eeprom"
+        size		= 0x800;
+        offset		= 0x8c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x20000;
+        offset		= 0x800000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x1000;
+        offset		= 0x81f000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x2000;
+        offset		= 0x820000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x22000;
+        offset		= 0x800000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size		= 0x100;
+        offset		= 0x8e0400;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega128B1
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x128b1";
+    desc	= "ATxmega128B1";
+    signature	= 0x1e 0x97 0x4d;
+    has_jtag	= yes;
+
+    memory "eeprom"
+        size		= 0x800;
+        offset		= 0x8c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x20000;
+        offset		= 0x800000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x2000;
+        offset		= 0x81e000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x2000;
+        offset		= 0x820000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x22000;
+        offset		= 0x800000;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size		= 0x100;
+        offset		= 0x8e0400;
+        page_size	= 0x100;
+        readsize	= 0x100;
+    ;
+
+    memory "fuse0"
+        size		= 1;
+        offset		= 0x8f0020;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega128B3
+#------------------------------------------------------------
+
+part parent "x128b1"
+    id		= "x128b3";
+    desc	= "ATxmega128B3";
+    signature	= 0x1e 0x97 0x4b;
+;
+
+#------------------------------------------------------------
+# ATxmega192C3
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x192c3";
+    desc	= "ATxmega192C3";
+    signature	= 0x1e 0x97 0x51;
+
+    memory "eeprom"
+        size		= 0x800;
+        offset		= 0x8c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x30000;
+        offset		= 0x800000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x2000;
+        offset		= 0x82e000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x2000;
+        offset		= 0x830000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x32000;
+        offset		= 0x800000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size		= 0x200;
+        offset		= 0x8e0400;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega192D3
+#------------------------------------------------------------
+
+part parent "x192c3"
+    id		= "x192d3";
+    desc	= "ATxmega192D3";
+    signature	= 0x1e 0x97 0x49;
+;
+
+#------------------------------------------------------------
+# ATxmega192A1
+#------------------------------------------------------------
+
+part parent "x192c3"
+    id		= "x192a1";
+    desc	= "ATxmega192A1";
+    signature	= 0x1e 0x97 0x4e;
+    has_jtag	= yes;
+
+    memory "fuse0"
+        size		= 1;
+        offset		= 0x8f0020;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega192A3
+#------------------------------------------------------------
+
+part parent "x192a1"
+    id		= "x192a3";
+    desc	= "ATxmega192A3";
+    signature	= 0x1e 0x97 0x44;
+;
+
+#------------------------------------------------------------
+# ATxmega192A3U
+#------------------------------------------------------------
+
+part parent "x192a1"
+    id		= "x192a3u";
+    desc	= "ATxmega192A3U";
+    signature	= 0x1e 0x97 0x44;
+;
+
+#------------------------------------------------------------
+# ATxmega256C3
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x256c3";
+    desc	= "ATxmega256C3";
+    signature	= 0x1e 0x98 0x46;
+
+    memory "eeprom"
+        size		= 0x1000;
+        offset		= 0x8c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x40000;
+        offset		= 0x800000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x2000;
+        offset		= 0x83e000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x2000;
+        offset		= 0x840000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x42000;
+        offset		= 0x800000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size		= 0x200;
+        offset		= 0x8e0400;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega256D3
+#------------------------------------------------------------
+
+part parent "x256c3"
+    id		= "x256d3";
+    desc	= "ATxmega256D3";
+    signature	= 0x1e 0x98 0x44;
+;
+
+#------------------------------------------------------------
+# ATxmega256A1
+#------------------------------------------------------------
+
+part parent "x256c3"
+    id		= "x256a1";
+    desc	= "ATxmega256A1";
+    signature	= 0x1e 0x98 0x46;
+    has_jtag	= yes;
+
+    memory "fuse0"
+        size		= 1;
+        offset		= 0x8f0020;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega256A3
+#------------------------------------------------------------
+
+part parent "x256a1"
+    id		= "x256a3";
+    desc	= "ATxmega256A3";
+    signature	= 0x1e 0x98 0x42;
+;
+
+#------------------------------------------------------------
+# ATxmega256A3U
+#------------------------------------------------------------
+
+part parent "x256a1"
+    id		= "x256a3u";
+    desc	= "ATxmega256A3U";
+    signature	= 0x1e 0x98 0x42;
+;
+
+#------------------------------------------------------------
+# ATxmega256A3B
+#------------------------------------------------------------
+
+part parent "x256a1"
+    id		= "x256a3b";
+    desc	= "ATxmega256A3B";
+    signature	= 0x1e 0x98 0x43;
+;
+
+#------------------------------------------------------------
+# ATxmega256A3BU
+#------------------------------------------------------------
+
+part parent "x256a1"
+    id		= "x256a3bu";
+    desc	= "ATxmega256A3BU";
+    signature	= 0x1e 0x98 0x43;
+;
+
+#------------------------------------------------------------
+# ATxmega384C3
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x384c3";
+    desc	= "ATxmega384C3";
+    signature	= 0x1e 0x98 0x45;
+
+    memory "eeprom"
+        size		= 0x1000;
+        offset		= 0x8c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x60000;
+        offset		= 0x800000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x2000;
+        offset		= 0x85e000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x2000;
+        offset		= 0x860000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x62000;
+        offset		= 0x800000;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size		= 0x200;
+        offset		= 0x8e0400;
+        page_size	= 0x200;
+        readsize	= 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega384D3
+#------------------------------------------------------------
+
+part parent "x384c3"
+    id		= "x384d3";
+    desc	= "ATxmega384D3";
+    signature	= 0x1e 0x98 0x47;
+;
+
+#------------------------------------------------------------
+# ATxmega8E5
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x8e5";
+    desc	= "ATxmega8E5";
+    signature	= 0x1e 0x93 0x41;
+
+    memory "eeprom"
+        size		= 0x0200;
+        offset		= 0x08c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x2000;
+        offset		= 0x0800000;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x800;
+        offset		= 0x00801800;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x800;
+        offset		= 0x00804000;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x2800;
+        offset		= 0x0800000;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size            = 0x80;
+        offset          = 0x8e0400;
+        page_size       = 0x80;
+        readsize	= 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega16E5
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x16e5";
+    desc	= "ATxmega16E5";
+    signature	= 0x1e 0x94 0x45;
+
+    memory "eeprom"
+        size		= 0x0200;
+        offset		= 0x08c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x4000;
+        offset		= 0x0800000;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x1000;
+        offset		= 0x00803000;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x1000;
+        offset		= 0x00804000;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x5000;
+        offset		= 0x0800000;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size            = 0x80;
+        offset          = 0x8e0400;
+        page_size       = 0x80;
+        readsize	= 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATxmega32E5
+#------------------------------------------------------------
+
+part parent ".xmega"
+    id		= "x32e5";
+    desc	= "ATxmega32E5";
+    signature	= 0x1e 0x95 0x4c;
+
+    memory "eeprom"
+        size		= 0x0400;
+        offset		= 0x08c0000;
+        page_size	= 0x20;
+        readsize	= 0x100;
+    ;
+
+    memory "application"
+        size		= 0x8000;
+        offset		= 0x0800000;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "apptable"
+        size		= 0x1000;
+        offset		= 0x00807000;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "boot"
+        size		= 0x1000;
+        offset		= 0x00804000;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "flash"
+        size		= 0x9000;
+        offset		= 0x0800000;
+        page_size	= 0x80;
+        readsize	= 0x100;
+    ;
+
+    memory "usersig"
+        size            = 0x80;
+        offset          = 0x8e0400;
+        page_size       = 0x80;
+        readsize	= 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR32UC3A0512
+#------------------------------------------------------------
+
+part
+    id		= "uc3a0512";
+    desc	= "AT32UC3A0512";
+    signature	= 0xED 0xC0 0x3F;
+    has_jtag	= yes;
+    is_avr32	= yes;
+
+    memory "flash"
+        paged           = yes;
+        page_size       = 512;           # bytes
+        readsize        = 512;           # bytes
+        num_pages       = 1024;          # could be set dynamicly
+        size            = 0x00080000;    # could be set dynamicly
+        offset          = 0x80000000;
+    ;
+;
+
+part parent "uc3a0512"
+    id		= "ucr2";
+    desc	= "deprecated, use 'uc3a0512'";
+;
+
+#------------------------------------------------------------
+# ATtiny1634.
+#------------------------------------------------------------
+
+part
+    id              = "t1634";
+    desc            = "ATtiny1634";
+     has_debugwire = yes;
+     flash_instr   = 0xB6, 0x01, 0x11;
+     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
+                0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+                0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode  = 0x86;
+    # avr910_devcode = 0x;
+    signature       = 0x1e 0x94 0x12;
+    pagel           = 0xB3;
+    bs2             = 0xB1;
+    reset	    = io;
+    chip_erase_delay = 9000;
+    pgm_enable       = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
+                       "x x x x x x x x x x x x x x x x";
+
+    chip_erase       = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
+                       "x x x x x x x x x x x x x x x x";
+
+    timeout         = 200;
+    stabdelay       = 100;
+    cmdexedelay     = 25;
+    synchloops      = 32;
+    bytedelay       = 0;
+    pollindex       = 3;
+    pollvalue       = 0x53;
+    predelay        = 1;
+    postdelay       = 1;
+    pollmethod      = 1;
+
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
+        0x4E, 0x5E, 0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E,
+        0x26, 0x36, 0x66, 0x76, 0x2A, 0x3A, 0x6A, 0x7A,
+        0x2E, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 0;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepulsewidth = 0;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
+    programfusepolltimeout = 5;
+    programlockpulsewidth = 0;
+    programlockpolltimeout = 5;
+
+    memory "eeprom"
+        paged           = no;
+        page_size       = 4;
+        size            = 256;
+        min_write_delay = 3600;
+        max_write_delay = 3600;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = " 1 0 1 0 0 0 0 0",
+                          " 0 0 0 x x x x a8",
+                          " a7 a6 a5 a4 a3 a2 a1 a0",
+                          " o o o o o o o o";
+
+        write           = " 1 1 0 0 0 0 0 0",
+                          " 0 0 0 x x x x a8",
+                          " a7 a6 a5 a4 a3 a2 a1 a0",
+                          " i i i i i i i i";
+
+   loadpage_lo   = "  1   1   0   0      0   0   0   1",
+           "  0   0   0   0      0   0   0   0",
+           "  0   0   0   0      0   0  a1  a0",
+           "  i   i   i   i      i   i   i   i";
+
+   writepage   = "  1   1   0   0      0   0   1   0",
+           "  0   0   x   x      x   x   x  a8",
+           " a7  a6  a5  a4     a3  a2   0   0",
+           "  x   x   x   x      x   x   x   x";
+
+   mode      = 0x41;
+   delay      = 5;
+   blocksize   = 4;
+   readsize   = 256;
+        ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 32;
+        num_pages       = 512;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = " 0 0 1 0 0 0 0 0",
+                          " 0 0 0 a12 a11 a10 a9 a8",
+                          " a7 a6 a5 a4 a3 a2 a1 a0",
+                          " o o o o o o o o";
+
+        read_hi          = " 0 0 1 0 1 0 0 0",
+                           " 0 0 0 a12 a11 a10 a9 a8",
+                           " a7 a6 a5 a4 a3 a2 a1 a0",
+                           " o o o o o o o o";
+
+        loadpage_lo     = " 0 1 0 0 0 0 0 0",
+                          " 0 0 0 x x x x x",
+                          " x x a5 a4 a3 a2 a1 a0",
+                          " i i i i i i i i";
+
+        loadpage_hi     = " 0 1 0 0 1 0 0 0",
+                          " 0 0 0 x x x x x",
+                          " x x a5 a4 a3 a2 a1 a0",
+                          " i i i i i i i i";
+
+        writepage       = " 0 1 0 0 1 1 0 0",
+                          " 0 0 0 a12 a11 a10 a9 a8",
+                          " a7 a6 x x x x x x",
+                          " x x x x x x x x";
+
+        mode        = 0x41;
+        delay       = 6;
+        blocksize   = 128;
+        readsize    = 256;
+
+        ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
+                          "x x x x x x x x o o o o o o o o";
+
+        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
+                          "x x x x x x x x i i i i i i i i";
+        ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
+                          "x x x x x x x x o o o o o o o o";
+
+        write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
+                          "x x x x x x x x i i i i i i i i";
+        ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
+                          "x x x x x x x x x x x o o o o o";
+
+        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
+                          "x x x x x x x x x x x i i i i i";
+        ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
+                          "x x x x x x x x x x x x x x o o";
+
+        write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
+                          "x x x x x x x x 1 1 1 1 1 1 i i";
+        ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0 o o o o o o o o";
+        ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
+                          "x x x x x x a1 a0 o o o o o o o o";
+        ;
+;
+
+#------------------------------------------------------------
+# Common values for reduced core tinys (4/5/9/10/20/40)
+#------------------------------------------------------------
+
+part
+    id		= ".reduced_core_tiny";
+    desc	= "Common values for reduced core tinys";
+    has_tpi	= yes;
+
+    memory "signature"
+        size		= 3;
+        offset		= 0x3fc0;
+        page_size	= 16;
+    ;
+
+    memory "fuse"
+        size		= 1;
+        offset		= 0x3f40;
+        page_size	= 16;
+	blocksize	= 4;
+    ;
+
+    memory "calibration"
+        size		= 1;
+        offset		= 0x3f80;
+        page_size	= 16;
+    ;
+
+    memory "lockbits"
+        size		= 1;
+        offset		= 0x3f00;
+        page_size	= 16;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny4
+#------------------------------------------------------------
+
+part parent ".reduced_core_tiny"
+    id		= "t4";
+    desc	= "ATtiny4";
+    signature	= 0x1e 0x8f 0x0a;
+
+    memory "flash"
+        size		= 512;
+        offset		= 0x4000;
+        page_size	= 16;
+        blocksize	= 128;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny5
+#------------------------------------------------------------
+
+part parent "t4"
+    id		= "t5";
+    desc	= "ATtiny5";
+    signature	= 0x1e 0x8f 0x09;
+;
+
+#------------------------------------------------------------
+# ATtiny9
+#------------------------------------------------------------
+
+part parent ".reduced_core_tiny"
+    id		= "t9";
+    desc	= "ATtiny9";
+    signature	= 0x1e 0x90 0x08;
+
+    memory "flash"
+        size		= 1024;
+        offset		= 0x4000;
+        page_size	= 16;
+        blocksize	= 128;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny10
+#------------------------------------------------------------
+
+part parent "t9"
+    id		= "t10";
+    desc	= "ATtiny10";
+    signature	= 0x1e 0x90 0x03;
+;
+
+#------------------------------------------------------------
+# ATtiny20
+#------------------------------------------------------------
+
+part parent ".reduced_core_tiny"
+    id          = "t20";
+    desc        = "ATtiny20";
+    signature   = 0x1e 0x91 0x0F;
+
+    memory "flash"
+        size            = 2048;
+        offset          = 0x4000;
+        page_size       = 16;
+        blocksize       = 128;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny40
+#------------------------------------------------------------
+
+part parent ".reduced_core_tiny"
+    id		= "t40";
+    desc	= "ATtiny40";
+    signature	= 0x1e 0x92 0x0E;
+
+    memory "flash"
+        size		= 4096;
+        offset		= 0x4000;
+        page_size	= 64;
+        blocksize	= 128;
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega406
+#------------------------------------------------------------
+
+part
+    id				= "m406";
+    desc			= "ATMEGA406";
+    has_jtag			= yes;
+    signature			= 0x1e 0x95 0x07;
+
+    # STK500 parameters (parallel programming IO lines)
+    pagel			= 0xa7;
+    bs2				= 0xa0;
+    serial			= no;
+    parallel			= yes;
+
+    # STK500v2 HV programming parameters, from XML
+    pp_controlstack		= 0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+				  0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+				  0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+				  0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+
+    # JTAG ICE mkII parameters, also from XML files
+    allowfullpagebitstream	= no;
+    enablepageprogramming	= yes;
+    idr				= 0x51;
+    rampz			= 0x00;
+    spmcr			= 0x57;
+    eecr			= 0x3f;
+
+    memory "eeprom"
+        paged		= no;
+        size		= 512;
+        page_size	= 4;
+        blocksize	= 4;
+	readsize	= 4;
+        num_pages	= 128;
+    ;
+
+    memory "flash"
+        paged		= yes;
+        size		= 40960;
+        page_size	= 128;
+        blocksize	= 128;
+	readsize	= 128;
+        num_pages	= 320;
+    ;
+
+    memory "hfuse"
+        size            = 1;
+    ;
+
+    memory "lfuse"
+        size            = 1;
+    ;
+
+    memory "lockbits"
+        size		= 1;
+    ;
+
+    memory "signature"
+        size            = 3;
+    ;
+;
+
+

--- a/keymapper/easykeymap/manuals/readme.txt
+++ b/keymapper/easykeymap/manuals/readme.txt
@@ -50,27 +50,7 @@ When you're done with your layout, save it with "File->Save Layout As...".
 Programming A Build
 ===================
 
-Build your layout with "File->Build Firmware...".  This will create a .hex file
-that can be loaded onto your custom keyboard.
+You can upload your firmware using Easy AVR or an external application.
 
-Open your programming tool.  In Windows, this is the Teensy Loader for boards
-with a Teensy controller (such as Phantom) or this is Atmel Flip for everything
-else.  If you're on Mac or Unix, ask Geekhack for help.  Load the .hex file
-you created above.
-
-Put your keyboard into boot mode.  Either press the key sequence that was
-previously programmed for boot, or use a hardware reset.  Teensy controllers
-have a button.  Most bpiphany controllers have a magnetic switch.  KMAC uses
-the Caps Lock key while plugging it in.  Other PDBs have a jumper.  Know your
-hardware.
-
-Once the bootloader is running, use your programming tool to connect and then
-program flash.  When that completes, use your programming tool to reboot the
-keyboard.
-
-This is the sequence in Flip:
-  Device->Select
-  Settings->Communications->USB, then press "Open"
-  File->Load HEX File
-  press "Run", let it reprogram
-  press "Start Application"
+To upload using EasyAVR, use the appropriate upload method for your device,
+check the "Uploading Firmware" help item for more details.

--- a/keymapper/easykeymap/manuals/upload.txt
+++ b/keymapper/easykeymap/manuals/upload.txt
@@ -1,0 +1,76 @@
+HOWTO: Easy AVR USB Keyboard Firmware - Uploading the firmware
+metalliqaz@geekhack
+
+==========================
+Bootloader and Boot Mode
+========================
+
+Easy AVR supports a number of ways to build and upload your firmware onto your 
+device. Different devices use different bootloaders.
+
+What is a bootloader? Well, on the USB AVR, a bootloader is basically a program 
+that you put in a special part of a microcontroller's memory that allows you to 
+program the microcontroller without any other external programming hardware.
+
+Different devices also use different bootloaders and thus there are different ways 
+of uploading the firmware, each particular to the bootloader. Teensy uses its own
+HalfKay bootloader. Most other devices will be using the DFU bootloader. If in 
+boot mode and your device shows up as a Mass Storage device, then it is using the 
+LUFA Mass Storage bootloader. There are other bootloaders out there.
+
+How to put your keyboard into boot mode?  Either press the key sequence that was
+previously programmed for boot, or use a hardware reset.  Teensy controllers
+have a button.  Most bpiphany controllers have a magnetic switch.  KMAC uses
+the Caps Lock key while plugging it in.  Other PDBs have a jumper. 
+Know your hardware.
+
+=========================
+Uploading from Easy AVR
+=======================
+
+Easy AVR supports uploading directly from within the tool as well. There are 
+different ways of uploading the firmware.
+
+Upload to Mass Storage
+    Use this option if your hardware shows up as a Mass Storage when connected 
+    and in boot mode. Put the device in boot mode, select the drive, wait for the 
+    success message and then unplug & plug your device back in to see changes. Done.
+
+Upload to Teensy
+    Use this option if you are using a Teensy. Put the device in boot mode, wait 
+    for success message. Done.
+
+Upload via DFU/FLIP
+    If your device does not show up as a Mass Storage in boot mode and you are not 
+    using a Teensy, chances are this method is for you. Put the device in boot 
+    mode, wait for success message. Done.
+
+==============================
+Uploading from External Tool
+============================
+
+Easy AVR can be used in conjunction with an external tool. There are two options 
+for exporting the firmware, either as a .hex or .bin.
+
+Build your layout with "File->Build Firmware..." or  "File->Build Binary...".
+This will create a .hex or .bin file that can be loaded onto your custom keyboard.
+
+Open your programming tool.  In Windows, this is the Teensy Loader for boards
+with a Teensy controller (such as Phantom) or this is Atmel Flip for almost 
+everything else.  If you're on Mac or Unix, ask Geekhack for help.  Load the .hex 
+file you created above. If your device shows up as a Mass Storage, then replace the 
+FLASH.BIN with your newly generated .bin file. It must be named FLASH.BIN.
+
+Put your keyboard into boot mode.
+
+Once the bootloader is running, use your programming tool to connect and then
+program flash.  When that completes, use your programming tool to reboot the
+keyboard.
+
+This is the sequence in Flip:
+  Device->Select
+  Settings->Communications->USB, then press "Open"
+  File->Load HEX File
+  press "Run", let it reprogram
+  press "Start Application"
+  

--- a/keymapper/easykeymap/manuals/upload.txt
+++ b/keymapper/easykeymap/manuals/upload.txt
@@ -45,26 +45,33 @@ Upload via DFU/FLIP
     using a Teensy, chances are this method is for you. Put the device in boot 
     mode, wait for success message. Done.
 
+Upload over Serial (ProMicro/CDC)
+    Use this option if you are using the ProMicro or a device with a CDC bootloader. 
+    If your device shows up as a serial device when in boot mode, this is likely
+    the method you have to use. Put the device in boot mode, wait for success message. 
+    Done.
+
 ==============================
 Uploading from External Tool
 ============================
 
-Easy AVR can be used in conjunction with an external tool. There are two options 
-for exporting the firmware, either as a .hex or .bin.
+Easy AVR can be used in conjunction with an external tool. Firmware can be 
+exported as an Intel Hex or binary file.
 
-Build your layout with "File->Build Firmware..." or  "File->Build Binary...".
+Build your layout with "File->Build Firmware..." and choose the file type.
 This will create a .hex or .bin file that can be loaded onto your custom keyboard.
 
 Open your programming tool.  In Windows, this is the Teensy Loader for boards
 with a Teensy controller (such as Phantom) or this is Atmel Flip for almost 
 everything else.  If you're on Mac or Unix, ask Geekhack for help.  Load the .hex 
 file you created above. If your device shows up as a Mass Storage, then replace the 
-FLASH.BIN with your newly generated .bin file. It must be named FLASH.BIN.
+FLASH.BIN with your newly generated .bin file. It must be named FLASH.BIN. Your
+device might be using a CDC bootloader, in that case you'll need to use avrdude.
 
 Put your keyboard into boot mode.
 
 Once the bootloader is running, use your programming tool to connect and then
-program flash.  When that completes, use your programming tool to reboot the
+flash the firmware.  When that completes, use your programming tool to reboot the
 keyboard.
 
 This is the sequence in Flip:


### PR DESCRIPTION
-- Added a Upload menu which can be used to program the keyboard directly from Easy AVR.
-- Added option to build firmware as .bin file.
-- Packaged corresponding external tools required for programming in "exttools" directly
-- Added Help menu item for new Upload feature

Currently upload works perfectly, with following bootloaders:
- Teensy, LUFA HID - Using Teensy CLI mod
- Atmel DFU, LUFA DFU - Using dfu-programmer
- LUFA Mass Storage - Using OS copy

Only other commonly used bootloader not supported as of now, but planned:
- LUFA CDC (Used in ProMicro/Arduino/etc) - Uses serial communication
