### PR TITLE
Fix Sixkeyboard LEDs always on

### DIFF
--- a/keymapper/easykeymap/boards/sixkeyboard.py
+++ b/keymapper/easykeymap/boards/sixkeyboard.py
@@ -46,8 +46,8 @@ matrix_hardware, matrix_strobe, matrix_sense = make_matrix_config(
 )
 
 num_leds = 7
-num_ind = 6
-num_bl_enab = 3
+num_ind = 7
+num_bl_enab = 2
 
 led_definition = [
     ('1', 'Unassigned'),
@@ -56,26 +56,25 @@ led_definition = [
     ('4', 'Unassigned'),
     ('5', 'Unassigned'),
     ('6', 'Unassigned'),
-    ('Underglow?', 'Unassigned')
+    ('Underside', 'Unassigned')
 ]
 
 led_hardware = [
 #       Port    Pin    Direction
-    ( REF_PORTC, 6, LED_DRIVER_PULLUP ),
-    ( REF_PORTB, 6, LED_DRIVER_PULLUP ),
-    ( REF_PORTB, 4, LED_DRIVER_PULLUP ),
-    ( REF_PORTD, 5, LED_DRIVER_PULLUP ),
-    ( REF_PORTD, 2, LED_DRIVER_PULLUP ),
-    ( REF_PORTD, 3, LED_DRIVER_PULLUP ),
-    ( REF_PORTC, 4, LED_DRIVER_PULLUP )
+    ( REF_PORTC, 6, LED_DRIVER_PULLDOWN ),
+    ( REF_PORTB, 6, LED_DRIVER_PULLDOWN ),
+    ( REF_PORTB, 4, LED_DRIVER_PULLDOWN ),
+    ( REF_PORTD, 5, LED_DRIVER_PULLDOWN ),
+    ( REF_PORTD, 2, LED_DRIVER_PULLDOWN ),
+    ( REF_PORTD, 3, LED_DRIVER_PULLDOWN ),
+    ( REF_PORTC, 4, LED_DRIVER_PULLDOWN )
 ]
 
-backlighting = True
+backlighting = False
 
 bl_modes = [
-    ( 0, 0, 0, 0, 0, 0 ),
-    ( 1, 1, 1, 1, 1, 1 ),
-    ( 0, 1, 0, 1, 1, 1 )
+    ( 0, 0, 0, 0, 0, 0, 0 ),
+    ( 1, 1, 1, 1, 1, 1, 1 )
 ]
 
 KMAC_key = None


### PR DESCRIPTION
Made the underside LED an indicator. Changed LEDs to pulldowns (as pullup they are always on). Set backlighting to False and adjusted modes accordingly.