### PR TITLE
adding layout support for JD40mkII

### DIFF
--- a/keymapper/easykeymap/boards/jd40v2.py
+++ b/keymapper/easykeymap/boards/jd40v2.py
@@ -22,7 +22,7 @@ from easykeymap.helper import make_matrix_config
 
 description = "JD40 MkII (Carpe Keyboards)"
 unique_id = "JD40_002"
-cfg_name = "jd40"
+cfg_name = "jd40v2"
 
 teensy = False
 hw_boot_key = True

--- a/keymapper/easykeymap/configs/jd40v2.cfg
+++ b/keymapper/easykeymap/configs/jd40v2.cfg
@@ -1,0 +1,21 @@
+[6.25 Space]
+# left CTRL 1.25
+MAKE_KEY(3, 0, 5, 4)
+# left ALT delete
+MAKE_SPACER(3, 3, 0)
+# left backspace delete
+MAKE_SPACER(3, 4, 0)
+# right SPACE extend
+MAKE_KEY(3, 5, 25, 4)
+# right ALT delete
+MAKE_SPACER(3, 6, 0)
+# right GUI delete
+MAKE_SPACER(3, 7, 0)
+# right FN 1.25
+MAKE_KEY(3, 8, 5, 4)
+# right CTRL 1.25
+MAKE_KEY(3, 9, 5, 4)
+# right period 1u
+MAKE_KEY(2, 9, 4, 4)
+# right shift 1.25
+MAKE_KEY(2, 10, 5, 4)


### PR DESCRIPTION
Added support for alternate layout on the JD40 MkII pcb for the 6.25u spacebar. 
Created new .cfg file for layout.
Edited keyboard to use unique filename instead of duplicate from old JD40.
Confirmed working.

I hope this is the correct way to do this, first time user here. 
Thanks