### PR TITLE
[fixes #101] Update EasyAVR for Python 3.9 support

### DIFF
--- a/keymapper/easykeymap/build.py
+++ b/keymapper/easykeymap/build.py
@@ -28,6 +28,7 @@ from .scancodes import scancodes
 from .templates import matrix_dims, macro_lengths, max_leds
 from .version import version_string
 import easykeymap.intelhex as intelhex
+import sys as sys
 
 
 NUM_LAYERS = 10
@@ -257,7 +258,8 @@ def overlay_macros(user_data, hex_data, external_data):
     offset = config.firmware.macro_map - start
     for index in index_list:
         short_array = array('H', [index])
-        byte_array[offset:offset+2] = array('B', short_array.tostring())
+        array_bytes = short_array.tobytes() if sys.version_info >= (3, 2) else short_array.tostring()
+        byte_array[offset:offset+2] = array('B', array_bytes)
         offset += 2
     # map the non-empty macros into the byte array
     for i in range(NUM_MACROS):

--- a/keymapper/easykeymap/gui/programdialog.py
+++ b/keymapper/easykeymap/gui/programdialog.py
@@ -129,7 +129,7 @@ class ProgramDialog(wx.Dialog):
         self.timer.Start(250)
 
     def OnTimer(self, event):
-        if not (self.runthread and self.runthread.isAlive()):
+        if not (self.runthread and self.runthread.is_alive()):
             self.log_text('\n\n')
             self.task_ch.Enable(True)
             self.run_btn.Enable(True)


### PR DESCRIPTION
As noted in #101, Python 3.9 removed some old constructs - this PR updates the code to use the replacements instead.